### PR TITLE
mkdtemp

### DIFF
--- a/TODO
+++ b/TODO
@@ -10,4 +10,3 @@ FireBuild TODO items
   usage
 - export process tree to a self contained html file including style sheets and
   D3.js
-- replace tempnam usage with using mkdtemp


### PR DESCRIPTION
Suppress this, and indeed become safe:

    /usr/bin/ld: [...] warning: the use of `tempnam' is dangerous, better use `mkstemp'