### PR TITLE
Allow further work after an intercepted exit

### DIFF
--- a/src/firebuild/ExecedProcess.cc
+++ b/src/firebuild/ExecedProcess.cc
@@ -59,7 +59,6 @@ void ExecedProcess::exit_result(const int status, const int64_t utime_m,
                                 const int64_t stime_m) {
   // store results for this process
   Process::exit_result(status, utime_m, stime_m);
-  set_state(FB_PROC_FINISHED);
   // propagate to parents exec()-ed this FireBuild process
   propagate_exit_status(status);
   // store data for shortcutting
@@ -196,7 +195,8 @@ void ExecedProcess::export2js(const unsigned int level,
 
   switch (state()) {
     case FB_PROC_FINISHED: {
-      fprintf(stream, "%s exit_status: %u,\n", indent, exit_status());
+      if (exit_status() != -1)
+        fprintf(stream, "%s exit_status: %u,\n", indent, exit_status());
       __attribute__((fallthrough));
     }
     case FB_PROC_EXECED: {

--- a/src/firebuild/Process.cc
+++ b/src/firebuild/Process.cc
@@ -45,8 +45,14 @@ void Process::update_rusage(const int64_t utime_m, const int64_t stime_m) {
 
 void Process::exit_result(const int status, const int64_t utime_m,
                           const int64_t stime_m) {
-  state_ = FB_PROC_FINISHED;
-  exit_status_ = status;
+  /* The kernel only lets the low 8 bits of the exit status go through.
+   * From the exit()/_exit() side, the remaining bits are lost (they are
+   * still there in on_exit() handlers).
+   * From wait()/waitpid() side, additional bits are used to denote exiting
+   * via signal.
+   * We use -1 if there's no exit status available (the process is still
+   * running, or exited due to an unhandled signal). */
+  exit_status_ = status & 0xff;
   update_rusage(utime_m, stime_m);
 }
 

--- a/src/firebuild/Process.h
+++ b/src/firebuild/Process.h
@@ -19,7 +19,7 @@ namespace firebuild {
 
 typedef enum {FB_PROC_RUNNING,   ///< process is running
               FB_PROC_EXECED,    ///< process finished running by exec()
-              FB_PROC_FINISHED,  ///< process exited cleanly
+              FB_PROC_FINISHED,  ///< process exited without exec() (exit, or crash on signal)
 } process_state;
 
 /**
@@ -142,7 +142,7 @@ class Process {
   int fb_pid_;       ///< internal FireBuild id for the process
   int pid_;          ///< UNIX pid
   int ppid_;         ///< UNIX ppid
-  int exit_status_;  ///< exit status, valid if state = FB_PROC_FINISHED
+  int exit_status_;  ///< exit status 0..255, or -1 if no exit() performed yet
   std::string wd_;  ///< Current working directory
   std::vector<FileFD*> fds_;  ///< Active file descriptors
   std::list<FileFD*> closed_fds_;  ///< Closed file descriptors

--- a/src/firebuild/ProcessTree.cc
+++ b/src/firebuild/ProcessTree.cc
@@ -43,9 +43,9 @@ void ProcessTree::insert(ExecedProcess *p, const int sock) {
   insert_process(p, sock);
 }
 
-void ProcessTree::exit(Process *p, const int sock) {
-  (void)p;
-  // TODO(rbalint) maybe this is not needed
+void ProcessTree::finished(const int sock) {
+  Process *p = sock2proc_[sock];
+  p->set_state(FB_PROC_FINISHED);
   sock2proc_.erase(sock);
 }
 

--- a/src/firebuild/ProcessTree.h
+++ b/src/firebuild/ProcessTree.h
@@ -40,7 +40,7 @@ class ProcessTree {
 
   void insert(Process *p, const int sock);
   void insert(ExecedProcess *p, const int sock);
-  void exit(Process *p, const int sock);
+  void finished(const int sock);
   static int64_t sum_rusage_recurse(Process *p);
   void export2js(FILE* stream);
   void export_profile2dot(FILE* stream);


### PR DESCRIPTION
There are cases when the intercepted process sends an exit message,
followed by other messages. Examples include intercept_exit() sending
this message straight away followed by custom atexit handlers, or
multi-threaded processes.

Let receiving such a message not change the process's state on the
server, apart from registering the exit status and resource usage. A
process only enters FB_PROC_FINISHED state when its connection closes.

Fixes #6