### PR TITLE
Common handling of system(), popen() and posix_spawn()

### DIFF
--- a/src/firebuild/CMakeLists.txt
+++ b/src/firebuild/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(firebuild
   firebuild_common.cc
   Process.cc
   ExecedProcess.cc
+  ExecedProcessParameters.cc
   ForkedProcess.cc
   ProcessFactory.cc
   ProcessTree.cc

--- a/src/firebuild/ExecedProcessParameters.cc
+++ b/src/firebuild/ExecedProcessParameters.cc
@@ -1,0 +1,31 @@
+/* Copyright (c) 2019 Interri Kft. */
+/* This file is an unpublished work. All rights reserved. */
+
+
+#include "firebuild/ExecedProcessParameters.h"
+
+namespace firebuild {
+
+ExecedProcessParameters::ExecedProcessParameters() : argv_() { }
+
+void ExecedProcessParameters::set_sh_c_command(const std::string &cmd) {
+  argv_.push_back("sh");
+  argv_.push_back("-c");
+  argv_.push_back(cmd);
+}
+
+std::string to_string(ExecedProcessParameters const &pp) {
+  std::string res = "[";
+  bool add_sep = false;
+  for (const auto &arg : pp.argv()) {
+    if (add_sep) {
+      res += ", ";
+    }
+    res += "\"" + arg + "\"";  // FIXME backslash-escape the special chars
+    add_sep = true;
+  }
+  res += "]";
+  return res;
+}
+
+}  // namespace firebuild

--- a/src/firebuild/ExecedProcessParameters.h
+++ b/src/firebuild/ExecedProcessParameters.h
@@ -1,0 +1,41 @@
+/* Copyright (c) 2019 Interri Kft. */
+/* This file is an unpublished work. All rights reserved. */
+
+
+#ifndef FIREBUILD_EXECEDPROCESSPARAMETERS_H_
+#define FIREBUILD_EXECEDPROCESSPARAMETERS_H_
+
+#include <string>
+#include <vector>
+
+#include "firebuild/ExecedProcessParameters.h"
+
+namespace firebuild {
+
+/**
+ * A thin class representing a process by its command line parameters
+ * (and later perhaps environment variables too).
+ */
+class ExecedProcessParameters {
+ public:
+  ExecedProcessParameters();
+  bool operator == (ExecedProcessParameters const &pp) const;
+
+  std::vector<std::string>& argv() {return argv_;}
+  const std::vector<std::string>& argv() const {return argv_;}
+
+  void set_sh_c_command(const std::string&);
+
+ private:
+  std::vector<std::string> argv_;
+  // TODO(egmont) add envp ?
+};
+
+inline bool ExecedProcessParameters::operator == (ExecedProcessParameters const &pp) const {
+  return (pp.argv() == argv());
+}
+
+std::string to_string(ExecedProcessParameters const&);
+
+}  // namespace firebuild
+#endif  // FIREBUILD_EXECEDPROCESSPARAMETERS_H_

--- a/src/firebuild/Process.h
+++ b/src/firebuild/Process.h
@@ -10,9 +10,11 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <algorithm>
 
 #include "firebuild/FileFD.h"
 #include "firebuild/FileUsage.h"
+#include "firebuild/ExecedProcessParameters.h"
 #include "firebuild/cxx_lang_utils.h"
 
 namespace firebuild {
@@ -66,6 +68,9 @@ class Process {
   bool remove_running_system_cmd(const std::string &cmd);
   bool has_running_system_cmd(const std::string &cmd) {
     return (running_system_cmds_.find(cmd) != running_system_cmds_.end());}
+  void add_expected_child(const ExecedProcessParameters &ec) {expected_children_.push_back(ec);}
+  bool remove_expected_child(const ExecedProcessParameters &ec);
+  void finish();
   virtual Process*  exec_proc() const = 0;
   void update_rusage(int64_t utime_m, int64_t stime_m);
   void sum_rusage(int64_t *sum_utime_m, int64_t *sum_stime_m);
@@ -155,6 +160,8 @@ class Process {
   std::vector<Process*> children_;  ///< children of the process
   /// commands of system(3) calls which did not finish yet
   std::multiset<std::string> running_system_cmds_;
+  /// commands of system(3), popen(3) and posix_spawn[p](3) that are expected to appear
+  std::vector<ExecedProcessParameters> expected_children_;
   Process * exec_child_;
   /** Add add ffd FileFD* to open fds */
   void add_filefd(const int fd, FileFD * ffd);

--- a/src/firebuild/ProcessTree.cc
+++ b/src/firebuild/ProcessTree.cc
@@ -45,7 +45,7 @@ void ProcessTree::insert(ExecedProcess *p, const int sock) {
 
 void ProcessTree::finished(const int sock) {
   Process *p = sock2proc_[sock];
-  p->set_state(FB_PROC_FINISHED);
+  p->finish();
   sock2proc_.erase(sock);
 }
 

--- a/src/firebuild/ProcessTree.h
+++ b/src/firebuild/ProcessTree.h
@@ -54,11 +54,13 @@ class ProcessTree {
       return NULL;
     }
   }
-  Process* find_exec_parent(int pid, int ppid, const std::string &cmd) {
+  // FIXME(egmont) the method name is bad, it does not suggest that it has
+  // a side effect. Also I find the code hard to read.
+  Process* find_exec_parent(int pid, int ppid, const ::firebuild::ExecedProcessParameters &epp) {
     auto exec_parent = pid2proc(pid);
     if (!exec_parent) {
       exec_parent = pid2proc(ppid);
-      if (!exec_parent || !exec_parent->has_running_system_cmd(cmd)) {
+      if (!exec_parent || !exec_parent->remove_expected_child(epp)) {
         return NULL;
       }
     }

--- a/src/firebuild/intercept.cc
+++ b/src/firebuild/intercept.cc
@@ -9,6 +9,7 @@
 #include <link.h>
 #include <sys/un.h>
 #include <sys/resource.h>
+#include <spawn.h>
 
 #include <cassert>
 #include <cstdarg>

--- a/src/firebuild/intercept.h
+++ b/src/firebuild/intercept.h
@@ -12,6 +12,7 @@
 #include <pthread.h>
 #include <dirent.h>
 #include <sys/socket.h>
+#include <spawn.h>
 
 #include <string>
 #include <vector>

--- a/src/firebuild/msg/fb-messages.proto
+++ b/src/firebuild/msg/fb-messages.proto
@@ -497,6 +497,58 @@ message SystemRet {
     optional int32 error_no = 3;
 }
 
+// popen(3)
+message Popen {
+    // command
+    optional bytes cmd = 1;
+    // type
+    optional bytes type = 2;
+}
+
+message PopenParent {
+    // return value
+    required int32 fd = 1;
+    // type
+    optional bytes type = 2;
+    // unused
+    optional int32 error_no = 3;
+}
+
+message PopenFailed {
+    // command, to let the supervisor remove it from expected_children
+    optional bytes cmd = 1;
+    // error no., when ret = -1
+    optional int32 error_no = 2;
+}
+
+// posix_spawn[p](3)
+message PosixSpawn {
+    // command
+    optional bytes file = 1;
+    // only argv, sending argc would be redundant
+    repeated bytes arg = 2;
+    // environment variables in unprocessed NAME=value form
+    repeated bytes env = 3;
+    // spawn or spawnp
+    required bool is_spawnp = 4;
+}
+
+message PosixSpawnParent {
+    // process id
+    required int64 pid = 1;
+    // child's process id
+    optional int64 child_pid = 2;
+    // unused
+    optional int32 error_no = 3;
+}
+
+message PosixSpawnFailed {
+    // command args, to let the supervisor remove it from expected_children
+    repeated bytes arg = 1;
+    // error no., when ret = -1
+    optional int32 error_no = 4;
+}
+
 message Process {
     // process id
     optional int64 pid = 23;
@@ -751,4 +803,10 @@ message InterceptorMsg {
     optional SysCall syscall = 61;
     optional System system = 62;
     optional SystemRet system_ret = 63;
+    optional Popen popen = 64;
+    optional PopenParent popen_parent = 65;
+    optional PopenFailed popen_failed = 66;
+    optional PosixSpawn posix_spawn = 67;
+    optional PosixSpawnParent posix_spawn_parent = 68;
+    optional PosixSpawnFailed posix_spawn_failed = 69;
 }


### PR DESCRIPTION
Store the set of children expected to appear via these libc calls in a
common array. Use this array to verify that indeed the expected children
appear, warn based on this if an unexpected child appears or if the list
is not empty when a process finishes.

Fixes #9