### PR TITLE
Destruct global data from the interceptor's on_exit handler

### DIFF
--- a/src/interceptor/intercept.cc
+++ b/src/interceptor/intercept.cc
@@ -295,6 +295,14 @@ void on_exit_handler(const int status, void *) {
   insert_debug_msg("our_on_exit_handler-begin");
   handle_exit(status);
   insert_debug_msg("our_on_exit_handler-end");
+
+  /* Destruct global stuff here so that valgrind doesn't complain.
+   * This is the last place anything from the interceptor code can be
+   * executed. Alas it's skipped if one does an _exit(). */
+  google::protobuf::ShutdownProtobufLibrary();
+  ic_orig_close(fb_sv_conn);
+  free(fb_conn_string);
+  delete fd_states;
 }
 
 void handle_exit(const int status) {


### PR DESCRIPTION
Fixes #50