### PR TITLE
Access fds in a more readable way

### DIFF
--- a/src/firebuild/process.h
+++ b/src/firebuild/process.h
@@ -75,9 +75,9 @@ class Process {
   void update_rusage(int64_t utime_u, int64_t stime_u);
   void sum_rusage(int64_t *sum_utime_u, int64_t *sum_stime_u);
   virtual void exit_result(int status, int64_t utime_u, int64_t stime_u);
-  FileFD* fd(int f) {
+  FileFD* get_fd(int fd) {
     try {
-      return fds_.at(f);
+      return fds_.at(fd);
     } catch (const std::out_of_range& oor) {
       return nullptr;
     }


### PR DESCRIPTION
What do you think of something like this?

There's a name conflict, and it's the standard notation for `fd` to mean a single integer as file descriptor, so I'd rather rename the method.

In fact, now that I'm further thinking about it, the array name is unfortunate: it mentions the semantics of the indices rather than the values. Maybe rename `fds_` to `filefds_`, and then `fd()` to `filefd()` or such?