### PR TITLE
Fix intercepting opendir()

### DIFF
--- a/src/common/msg/fb-messages.proto
+++ b/src/common/msg/fb-messages.proto
@@ -83,13 +83,6 @@ message Open {
     optional bool created = 7;
 }
 
-message OpenDir {
-    // path
-    optional bytes name = 1;
-    // error no., when ret = -1
-    optional int32 error_no = 2;
-}
-
 message FReOpen {
     // file path
     optional bytes filename = 1;
@@ -698,7 +691,6 @@ message InterceptorMsg {
     optional LAObjSearch la_objsearch = 51;
     optional LAObjOpen la_objopen = 52;
     optional DLClose dlclose = 53;
-    optional OpenDir opendir = 54;
     optional UTime utime = 55;
     optional FUTime futime = 56;
     optional FBError fb_error = 57;

--- a/src/firebuild/firebuild.cc
+++ b/src/firebuild/firebuild.cc
@@ -410,8 +410,7 @@ void proc_ic_msg(const firebuild::msg::InterceptorMsg &ic_msg,
              ic_msg.has_dup3() ||
              ic_msg.has_dup() ||
              ic_msg.has_fcntl() ||
-             ic_msg.has_chdir() ||
-             ic_msg.has_opendir()) {
+             ic_msg.has_chdir()) {
     try {
       ::firebuild::Process *proc = proc_tree->Sock2Proc(fd_conn);
       if (ic_msg.has_exit()) {

--- a/src/interceptor/ic_file_ops.cc
+++ b/src/interceptor/ic_file_ops.cc
@@ -560,8 +560,6 @@ IC2_SIMPLE_4P(int, IC2_WITH_RET, Open, open, const char *, file,
               const int, flags, const int, mode, bool, created)
 /* Intercept close */
 IC2_SIMPLE_1P(int, IC2_NO_RET, Close, close, const int, fd)
-/* Intercept opendir */
-IC2_SIMPLE_1P(void*, IC2_NO_RET, OpenDir, opendir, const char *, name)
 /* Intercept chdir */
 IC2_SIMPLE_1P(int, IC2_NO_RET, ChDir, chdir, const char *, dir)
 

--- a/src/interceptor/ic_file_ops.h
+++ b/src/interceptor/ic_file_ops.h
@@ -940,8 +940,9 @@ IC(void*, dlopen, (const char *filename, int flag), {
   })
 
 // dirent.h
-IC(DIR *, opendir, (const char *name), {
-    ret = orig_fn(name); intercept_opendir(name, ret);})
+IC_GENERIC(DIR *, opendir, (const char *name), {
+    ret = orig_fn(name);
+    intercept_open(name, O_RDONLY|O_CLOEXEC|O_DIRECTORY, 0, (ret == NULL)?-1:dirfd(ret));})
 IC_GENERIC(struct dirent *, readdir, (DIR *dirp), {
     ret = orig_fn(dirp);})
 IC_GENERIC(struct dirent64 *, readdir64, (DIR *dirp), {


### PR DESCRIPTION
As of the recent closedir() fix, `ls` complains about fd leakage. Indeed, we didn't register directories getting opened.

[Is there a preference whether to map to essentially the same event as `open` in the interceptor to the same message type (as I did now), or keep it a separate message type and map to the same data structures in the supervisor?]