### PR TITLE
gcov: Reorganize tree

### DIFF
--- a/etc/firebuildrc
+++ b/etc/firebuildrc
@@ -5,7 +5,7 @@ version = 1.0;
 // enviromnent variables passed to the build command
 env_vars = {
   // the following environment variables are passed to the build command unchanged
-  pass_through = [ "PATH", "SHELL", "PWD", "LD_LIBRARY_PATH" ];
+  pass_through = [ "PATH", "SHELL", "PWD", "LD_LIBRARY_PATH", "GCOV_PREFIX", "GCOV_PREFIX_STRIP" ];
 
   // These env vars are skipped when computing an intercepted command's fingerprint.
   fingerprint_skip = [ "MAKE_TERMOUT", "MAKE_TERMERR" ];

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -2,6 +2,8 @@
 export LD_LIBRARY_PATH=$(realpath ../src/interceptor)
 export PATH=$(realpath ../src/firebuild):$PATH
 export FIREBUILD_CACHE_DIR=$(realpath ./test_cache_dir)
+export GCOV_PREFIX=$(realpath ..)/gcov
+export GCOV_PREFIX_STRIP=$(realpath .. | tr -dc / | wc -c)
 
 function strip_stderr () {
     awk '/^==[0-9]*== $/ {next} /FILE DESCRIPTORS: 0 open at exit/ {next} {print}' < $1

--- a/tools/calculate-coverage
+++ b/tools/calculate-coverage
@@ -2,12 +2,14 @@
 
 set -e
 
-find . -name '*.gcno' | grep CMakeFiles/ | while read f; do
-    cp $f $(dirname $f| xargs dirname | xargs dirname)/$(basename $f)
+find . -name '*.gcno' | grep -v /gcov/ | while read f; do
+    mkdir -p gcov/$(dirname $f)
+    ln -sf $(realpath $f) gcov/$f
 done
-lcov -q -c -d . --no-external -o tmp.info
-lcov -q -r tmp.info -o coverage-incl-tests.info '*.pb.*'
-genhtml coverage-incl-tests.info
-lcov -q -r coverage-incl-tests.info -o coverage-excl-tests.info '*/test/*.c*'
+
+lcov -q -c -d . --no-external -o gcov/tmp.info
+lcov -q -r gcov/tmp.info -o gcov/coverage-incl-tests.info '*.pb.*'
+genhtml -o gcovhtml gcov/coverage-incl-tests.info
+lcov -q -r gcov/coverage-incl-tests.info -o gcov/coverage-excl-tests.info '*/test/*.c*'
 echo "Line coverage rate, excluding test files:"
-lcov --summary coverage-excl-tests.info  2>&1 | grep '^  lines' | sed 's/  lines.*: \([^%]*\)%.*/\1/'
+lcov --summary gcov/coverage-excl-tests.info 2>&1 | grep '^  lines' | sed 's/  lines.*: \([^%]*\)%.*/\1/'


### PR DESCRIPTION
Make sure that tests measured with gcov place their *.gcda files under
the gcov directory. Do all the intermediate computations here too.

Place the coverage report under the gcovhtml directory.

---

Note1: The loop that I modify (the old version with `grep CMakeFiles` and `xargs dirname | xargs dirname`) wasn't needed: the files were all at the desired location even with this copying. However, a similar loop is needed now to move (or symlink) everything to the new `gcov` directory.

Note2: I tried to do a `cd gcov` before the lcov commands, it didn't work (lcov generated empty files), I don't know why.