### PR TITLE
ci: Run CI for pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
This make results show up in the PR itself thus the reviewer does not have to
look it up in the originating repo.