### PR TITLE
WIP interceptor: Lock the entire intercepted operation

### DIFF
--- a/src/interceptor/CMakeLists.txt
+++ b/src/interceptor/CMakeLists.txt
@@ -21,6 +21,7 @@ add_custom_command (
   tpl_read.c
   tpl_readlink.c
   tpl_skip.c
+  tpl_syscall.c
   tpl_system.c
   tpl_write.c
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -1050,6 +1050,7 @@ generate("long", "sysconf", "int name",
 # Intercept syscall
 # FIXME retval == -1 does not have a generic meaning
 generate("long", "syscall", "long number, ...",
+         tpl="syscall",
          send_ret_on_success=True,
          ack=True)
 

--- a/src/interceptor/intercept.cc
+++ b/src/interceptor/intercept.cc
@@ -112,7 +112,7 @@ void insert_end_marker(const char* m) {
 
 /** Get next unique ACK id */
 static int get_next_ack_id() {
-  return __atomic_add_fetch(&ack_id, 1, __ATOMIC_SEQ_CST);
+  return ack_id++;
 }
 
 void fb_send_msg_and_check_ack(void* void_ic_msg, int fd) {
@@ -347,16 +347,12 @@ static void fb_ic_cleanup() {
 
 /** wrapper for send() retrying on recoverable errors*/
 ssize_t fb_write_buf(const int fd, const void * const buf, const size_t count) {
-  pthread_mutex_lock(&ic_global_lock);
-  FB_IO_OP_BUF(ic_orig_send, fd, buf, count, 0, {
-      pthread_mutex_unlock(&ic_global_lock);});
+  FB_IO_OP_BUF(ic_orig_send, fd, buf, count, 0, {});
 }
 
 /** wrapper for recv() retrying on recoverable errors*/
 ssize_t fb_read_buf(const int fd,  void * const buf, const size_t count) {
-  pthread_mutex_lock(&ic_global_lock);
-  FB_IO_OP_BUF(ic_orig_recv, fd, buf, count, 0, {
-      pthread_mutex_unlock(&ic_global_lock);});
+  FB_IO_OP_BUF(ic_orig_recv, fd, buf, count, 0, {});
 }
 
 /** Send error message to supervisor */

--- a/src/interceptor/interceptors.h
+++ b/src/interceptor/interceptors.h
@@ -17,6 +17,7 @@
 #include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
+#include <sys/syscall.h>
 #include <sys/time.h>
 #include <sys/timeb.h>
 #include <bits/timex.h>

--- a/src/interceptor/tpl.c
+++ b/src/interceptor/tpl.c
@@ -84,10 +84,15 @@ ic_orig_{{ func }} = ({{ rettype }}(*)({{ sig_str }})) dlsym(RTLD_NEXT, "{{ func
   {{ rettype }} ret;
 ###     endif
 
+  /* Maybe don't intercept? */
+###     block no_intercept
+###     endblock no_intercept
+
   /* Warm up */
 ###     if not no_saved_errno
   int saved_errno = errno;
 ###     endif
+  pthread_mutex_lock(&ic_global_lock);
   fb_ic_load();
 
   if (insert_trace_markers) {
@@ -222,6 +227,7 @@ ic_orig_{{ func }} = ({{ rettype }}(*)({{ sig_str }})) dlsym(RTLD_NEXT, "{{ func
     insert_end_marker(debug_buf);
   }
   intercept_on = NULL;
+  pthread_mutex_unlock(&ic_global_lock);
 ###     if not no_saved_errno
   errno = saved_errno;
 ###     endif

--- a/src/interceptor/tpl_exit.c
+++ b/src/interceptor/tpl_exit.c
@@ -10,6 +10,7 @@
 ### block body
   /* Exit handlers may call intercepted functions */
   intercept_on = NULL;
+  pthread_mutex_unlock(&ic_global_lock);
 
   /* Mark the end now */
   insert_end_marker("{{ func }}");

--- a/src/interceptor/tpl_fork.c
+++ b/src/interceptor/tpl_fork.c
@@ -17,9 +17,8 @@
 
     reset_interceptors();
     ic_pid = getpid();
-    // unlock global interceptor lock if it is locked
+    // relock global interceptor lock if it is unlocked – it should be locked, though
     pthread_mutex_trylock(&ic_global_lock);
-    pthread_mutex_unlock(&ic_global_lock);
     // reconnect to supervisor
     fb_init_supervisor_conn();
 

--- a/src/interceptor/tpl_main.c
+++ b/src/interceptor/tpl_main.c
@@ -17,6 +17,7 @@
 
   /* Get out of the way from others */
   intercept_on = NULL;
+  pthread_mutex_unlock(&ic_global_lock);
 
   /* Mark the end now */
   insert_end_marker("{{ func }}");

--- a/src/interceptor/tpl_syscall.c
+++ b/src/interceptor/tpl_syscall.c
@@ -1,0 +1,24 @@
+{# ------------------------------------------------------------------ #}
+{# Copyright (c) 2020 Interri Kft.                                    #}
+{# This file is an unpublished work. All rights reserved.             #}
+{# ------------------------------------------------------------------ #}
+{# Template for the fcntl() family.                                   #}
+{# ------------------------------------------------------------------ #}
+### extends "tpl.c"
+
+### block no_intercept
+  /* futex() doesn't have a glibc wrapper, pthread_mutex_[un]lock()
+   * maps into syscall(__NR_futex, ...).
+   * We don't need to notify the supervisor about these.
+   * More importantly, we must return before locking, in order to
+   * avoid a deadlock with this very same mutex that we guard the
+   * communication with. */
+  if (number == __NR_futex) {
+    void *args = __builtin_apply_args();
+    {%+ if rettype != 'void' %}void const * const result ={% endif -%}
+    __builtin_apply((void (*)(...))(void *)ic_orig_{{ func }}, args, 100);
+    {%+ if rettype != 'void' %}ret = *({{ rettype }}*)result;{% endif %}
+
+    return ret;
+  }
+### endblock no_intercept


### PR DESCRIPTION
FYI This is what I'm planning to do, and it significantly improves the current situation. Alas, it still deadlocks in <1% of the cases.

---

Lock the entire block of calling the original method, notifying the
supervisor and waiting for ack. This prevents many race conditions.

Fixes #27, fixes 162, fixes 201