### PR TITLE
supervisor: Free up process data after storing in the cache

### DIFF
--- a/src/firebuild/execed_process.cc
+++ b/src/firebuild/execed_process.cc
@@ -16,6 +16,7 @@
 #include "firebuild/utils.h"
 
 extern libconfig::Config * cfg;
+extern bool generate_report;
 
 namespace firebuild {
 
@@ -96,6 +97,18 @@ void ExecedProcess::do_finalize() {
   // store data for shortcutting
   if (cacher_ && !was_shortcut() && can_shortcut()) {
     cacher_->store(this);
+  }
+
+  // free up process data that we no longer need
+  for (auto& fu : file_usages()) {
+    delete fu.second;
+  }
+  file_usages().clear();
+  fds()->clear();
+  if (!generate_report) {
+    args().clear();
+    env_vars().clear();
+    libs().clear();
   }
 
   // Call the base class's method

--- a/src/firebuild/firebuild.cc
+++ b/src/firebuild/firebuild.cc
@@ -37,6 +37,7 @@
 
 /** global configuration */
 libconfig::Config * cfg;
+bool generate_report = false;
 
 namespace {
 
@@ -67,7 +68,6 @@ static int inherited_fd = -1;
 static int child_pid, child_ret = 1;
 static google::protobuf::io::FileOutputStream * error_fos;
 static bool insert_trace_markers = false;
-static bool generate_report = false;
 static const char *report_file = "firebuild-build-report.html";
 static firebuild::ProcessTree *proc_tree;
 static firebuild::ExecedProcessCacher *cacher;

--- a/src/firebuild/process.h
+++ b/src/firebuild/process.h
@@ -140,6 +140,7 @@ class Process {
       return nullptr;
     }
   }
+  std::shared_ptr<std::vector<std::shared_ptr<FileFD>>> fds() {return fds_;}
   void set_fds(std::shared_ptr<std::vector<std::shared_ptr<FileFD>>> fds) {fds_ = fds;}
   std::shared_ptr<std::vector<std::shared_ptr<FileFD>>> pass_on_fds(bool execed = true);
 


### PR DESCRIPTION
Fixes #271

~ ~ ~

Note: instead of the manual `new` / `delete` pair, we could go with a shared_ptr. However, this pointer is not actually shared, we'd use it solely for automatic memory management, paying the price of a slightly higher memory usage and runtime cost. And a cleaner code. I'm uncertain.