### PR TITLE
supervisor: Disable shortcutting if a process reads from an inherited fd

### DIFF
--- a/src/firebuild/firebuild.cc
+++ b/src/firebuild/firebuild.cc
@@ -477,6 +477,7 @@ void proc_ic_msg(uint32_t ack_num,
              tag == FBB_TAG_fcntl ||
              tag == FBB_TAG_ioctl ||
              tag == FBB_TAG_chdir ||
+             tag == FBB_TAG_read ||
              tag == FBB_TAG_write) {
     try {
       ::firebuild::Process *proc = proc_tree->Sock2Proc(fd_conn);
@@ -609,6 +610,8 @@ void proc_ic_msg(uint32_t ack_num,
         ::firebuild::ProcessPBAdaptor::msg(proc, reinterpret_cast<const FBB_ioctl *>(fbb_buf));
       } else if (tag == FBB_TAG_chdir) {
         ::firebuild::ProcessPBAdaptor::msg(proc, reinterpret_cast<const FBB_chdir *>(fbb_buf));
+      } else if (tag == FBB_TAG_read) {
+        ::firebuild::ProcessPBAdaptor::msg(proc, reinterpret_cast<const FBB_read *>(fbb_buf));
       } else if (tag == FBB_TAG_write) {
         ::firebuild::ProcessPBAdaptor::msg(proc, reinterpret_cast<const FBB_write *>(fbb_buf));
       }

--- a/src/firebuild/process.cc
+++ b/src/firebuild/process.cc
@@ -321,6 +321,20 @@ int Process::handle_ioctl(const int fd, const int cmd,
   }
 }
 
+void Process::handle_read(const int fd) {
+  if (!get_fd(fd)) {
+    disable_shortcutting_bubble_up("Process successfully read from (" +
+                                   std::to_string(fd) +
+                                   ") which is known to be closed, which means interception"
+                                   " missed at least one open()");
+    return;
+  }
+  /* Note: this doesn't disable any shortcutting if (*fds_)[fd]->opened_by() == this,
+   * i.e. the file was opened by the current process. */
+  disable_shortcutting_bubble_up_to_excl((*fds_)[fd]->opened_by(),
+                                         "Process read from inherited fd " + std::to_string(fd));
+}
+
 void Process::handle_write(const int fd) {
   if (!get_fd(fd)) {
     disable_shortcutting_bubble_up("Process successfully wrote to (" +

--- a/src/firebuild/process.h
+++ b/src/firebuild/process.h
@@ -247,6 +247,12 @@ class Process {
 
 
   /**
+   * Handle read() in the monitored process
+   * @param fd file descriptor
+   */
+  void handle_read(const int fd);
+
+  /**
    * Handle write() in the monitored process
    * @param fd file descriptor
    */

--- a/src/firebuild/process_proto_adaptor.cc
+++ b/src/firebuild/process_proto_adaptor.cc
@@ -74,6 +74,14 @@ int ProcessPBAdaptor::msg(Process *p, const FBB_write *w) {
   return 0;
 }
 
+int ProcessPBAdaptor::msg(Process *p, const FBB_read *r) {
+  const int error = fbb_read_get_error_no_with_fallback(r, 0);
+  if (error == 0) {
+    p->handle_write(fbb_read_get_fd(r));
+  }
+  return 0;
+}
+
 int ProcessPBAdaptor::msg(Process *p, const FBB_chdir *c) {
   const int error = fbb_chdir_get_error_no_with_fallback(c, 0);
   if (error == 0) {

--- a/src/firebuild/process_proto_adaptor.h
+++ b/src/firebuild/process_proto_adaptor.h
@@ -28,6 +28,7 @@ class ProcessPBAdaptor {
   static int msg(Process *p, const FBB_rename *r);
   static int msg(Process *p, const FBB_fcntl *f);
   static int msg(Process *p, const FBB_ioctl *i);
+  static int msg(Process *p, const FBB_read *r);
   static int msg(Process *p, const FBB_write *w);
   static int msg(Process *p, const FBB_chdir *c);
 


### PR DESCRIPTION
Followup of commit 9e0ac23703dc02ba4fbbfdd58b1afc9e45f43425.