### PR TITLE
supervisor: Fix disabling shortcutting on read

### DIFF
--- a/src/firebuild/process_proto_adaptor.cc
+++ b/src/firebuild/process_proto_adaptor.cc
@@ -66,18 +66,18 @@ int ProcessPBAdaptor::msg(Process *p, const FBB_ioctl *f) {
   return p->handle_ioctl(fbb_ioctl_get_fd(f), fbb_ioctl_get_cmd(f), ret, error);
 }
 
-int ProcessPBAdaptor::msg(Process *p, const FBB_write *w) {
-  const int error = fbb_write_get_error_no_with_fallback(w, 0);
+int ProcessPBAdaptor::msg(Process *p, const FBB_read *r) {
+  const int error = fbb_read_get_error_no_with_fallback(r, 0);
   if (error == 0) {
-    p->handle_write(fbb_write_get_fd(w));
+    p->handle_read(fbb_read_get_fd(r));
   }
   return 0;
 }
 
-int ProcessPBAdaptor::msg(Process *p, const FBB_read *r) {
-  const int error = fbb_read_get_error_no_with_fallback(r, 0);
+int ProcessPBAdaptor::msg(Process *p, const FBB_write *w) {
+  const int error = fbb_write_get_error_no_with_fallback(w, 0);
   if (error == 0) {
-    p->handle_write(fbb_read_get_fd(r));
+    p->handle_write(fbb_write_get_fd(w));
   }
   return 0;
 }


### PR DESCRIPTION
Fixup of commit 6bb095ec334c8e20b9abeb8823f49c688251bf77 to call the
proper handler method.

(This didn't cause any problem, apart from a faulty debug message.)

(Also shuffle the methods around to be consistent with the .h file.)