### PR TITLE
interceptor: Do not lock for read and write operations

### DIFF
--- a/src/interceptor/tpl_read.c
+++ b/src/interceptor/tpl_read.c
@@ -7,11 +7,22 @@
 ### extends "tpl.c"
 
 {% set msg = "read" %}
-{% set send_msg_condition = "(fd < 0 || fd >= IC_FD_STATES_SIZE || ic_fd_states[fd].read == false)" %}
+{# No locking around the read(): see issue #279 #}
+{% set global_lock = False %}
 
 ### block send_msg
-  {{ super() }}
-  if (fd >= 0 && fd < IC_FD_STATES_SIZE) {
-    ic_fd_states[fd].read = true;
+  {# Acquire the lock if sending a message #}
+  if (fd < 0 || fd >= IC_FD_STATES_SIZE || ic_fd_states[fd].read == false) {
+    /* Need to notify the supervisor */
+
+    {{ grab_lock_if_needed('true') | indent(2) }}
+
+    {{ super() | indent(2) }}
+
+    if (fd >= 0 && fd < IC_FD_STATES_SIZE) {
+      ic_fd_states[fd].read = true;
+    }
+
+    {{ release_lock_if_needed() | indent(2) }}
   }
 ### endblock send_msg

--- a/src/interceptor/tpl_write.c
+++ b/src/interceptor/tpl_write.c
@@ -7,11 +7,22 @@
 ### extends "tpl.c"
 
 {% set msg = "write" %}
-{% set send_msg_condition = "(fd < 0 || fd >= IC_FD_STATES_SIZE || ic_fd_states[fd].written == false)" %}
+{# No locking around the write(): see issue #279 #}
+{% set global_lock = False %}
 
 ### block send_msg
-  {{ super() }}
-  if (fd >= 0 && fd < IC_FD_STATES_SIZE) {
-    ic_fd_states[fd].written = true;
+  {# Acquire the lock if sending a message #}
+  if (fd < 0 || fd >= IC_FD_STATES_SIZE || ic_fd_states[fd].written == false) {
+    /* Need to notify the supervisor */
+
+    {{ grab_lock_if_needed('true') | indent(2) }}
+
+    {{ super() | indent(2) }}
+
+    if (fd >= 0 && fd < IC_FD_STATES_SIZE) {
+      ic_fd_states[fd].written = true;
+    }
+
+    {{ release_lock_if_needed() | indent(2) }}
   }
 ### endblock send_msg


### PR DESCRIPTION
Lock for the communication, though.

Fixes #278, fixes #279

-----

Please pick one:
 - either the first approach (in the `279-no-lock-on-read-write` branch)
 - or the second approach, which is this one (the `279-no-lock-on-read-write-2` branch)

To confuse you, they have the same commit message :)

I suspect you'll prefer the second approach (this one), so I'm sending out the PR for this.