### PR TITLE
ci: Run actions on PRs only, not for pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
This prevents running actions twice for PRs and branches which are
not part of a PR can still be tested by reverting this commit.