### PR TITLE
interceptor: Preserve essential environment variables

### DIFF
--- a/etc/firebuild.conf
+++ b/etc/firebuild.conf
@@ -11,8 +11,8 @@ env_vars = {
   fingerprint_skip = [ "MAKE_TERMOUT", "MAKE_TERMERR" ];
 
   // the folloving env vars are pre-set to the values configured below
-  // Note that FB_SOCKET is also set by firebuild internally 
-  preset = ["LD_PRELOAD=libfbintercept.so"];
+  // Note that FB_SOCKET and LD_PRELOAD are also set by firebuild internally
+  preset = [];
 };
 
 processes = {

--- a/src/firebuild/firebuild.cc
+++ b/src/firebuild/firebuild.cc
@@ -111,6 +111,7 @@ static char** get_sanitized_env() {
     env_v.push_back(preset[i]);
     FB_DEBUG(firebuild::FB_DEBUG_PROC, " " + env_v.back());
   }
+  env_v.push_back("LD_PRELOAD=libfbintercept.so");
   env_v.push_back("FB_SOCKET=" + std::string(fb_conn_string));
   FB_DEBUG(firebuild::FB_DEBUG_PROC, " " + env_v.back());
 

--- a/src/interceptor/env.c
+++ b/src/interceptor/env.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2014 Balint Reczey <balint@balintreczey.hu> */
+/* Copyright (c) 2020 Interri Kft. */
 /* This file is an unpublished work. All rights reserved. */
 
 
@@ -6,7 +7,20 @@
 
 #include <unistd.h>
 #include <assert.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+
+#include "interceptor/intercept.h"
+
+
+/* Avoid typos in repetitive names */
+#define FB_INSERT_TRACE_MARKERS "FB_INSERT_TRACE_MARKERS"
+#define FB_SOCKET               "FB_SOCKET"
+#define LD_LIBRARY_PATH         "LD_LIBRARY_PATH"
+#define LD_PRELOAD              "LD_PRELOAD"
+#define LIBFBINTERCEPT_SO       "libfbintercept.so"
+#define LIBFBINTERCEPT_SO_LEN   ((int) strlen(LIBFBINTERCEPT_SO))
 
 void get_argv_env(char *** argv, char ***env) {
   char* arg = *(__environ - 2);
@@ -26,3 +40,261 @@ void get_argv_env(char *** argv, char ***env) {
 
 // TODO(rbalint) for valgrind
 // void free_arc_argv_env()
+
+
+/* Like getenv(), but from a custom environment array */
+static char *getenv_from(char **env, const char *name) {
+  int name_len = strlen(name);
+  for (int i = 0; env[i] != NULL; i++) {
+    if (memcmp(name, env[i], name_len) == 0 && env[i][name_len] == '=') {
+      return env[i] + name_len + 1;
+    }
+  }
+  return NULL;
+}
+
+static bool fb_insert_trace_markers_needs_fixup(char **env) {
+  char *current_value = getenv_from(env, FB_INSERT_TRACE_MARKERS);
+  if (current_value == NULL && !insert_trace_markers) {
+    return false;
+  }
+  if (current_value == NULL || !insert_trace_markers) {
+    return true;
+  }
+  return strcmp(current_value, "1") != 0;
+}
+
+static bool fb_socket_needs_fixup(char **env) {
+  char *current_value = getenv_from(env, FB_SOCKET);
+  return current_value == NULL || strcmp(current_value, fb_conn_string) != 0;
+}
+
+static bool ld_library_path_needs_fixup(char **env) {
+  if (env_ld_library_path == NULL) {
+    return false;
+  }
+  char *current_value = getenv_from(env, LD_LIBRARY_PATH);
+
+  // FIXME use more precise search (split both values at ':' or ';', and compare the components)
+  return current_value == NULL || strstr(current_value, env_ld_library_path) == NULL;
+}
+
+static bool ld_preload_needs_fixup(char **env) {
+  char *current_value = getenv_from(env, LD_PRELOAD);
+  if (current_value == NULL) {
+    return true;
+  }
+
+  /* "libfbintercept.so" has to occur exactly once, at the very end (see #155). */
+  int current_value_len = strlen(current_value);
+
+  /* Is the current value long enough? */
+  if (current_value_len < LIBFBINTERCEPT_SO_LEN) {
+    return true;
+  }
+  /* Does the current value end in "libfbintercept.so"? */
+  if (strcmp(current_value + current_value_len - LIBFBINTERCEPT_SO_LEN, LIBFBINTERCEPT_SO) != 0) {
+    return true;
+  }
+  /* If the current value is longer, is "libfbintercept.so" preceded by a separator (' ' or ':')? */
+  if (current_value_len > LIBFBINTERCEPT_SO_LEN &&
+      (current_value[current_value_len - LIBFBINTERCEPT_SO_LEN - 1] != ' ' &&
+       current_value[current_value_len - LIBFBINTERCEPT_SO_LEN - 1] != ':')) {
+    return true;
+  }
+
+  return false;
+}
+
+bool env_needs_fixup(char **env) {
+  return fb_insert_trace_markers_needs_fixup(env) ||
+      fb_socket_needs_fixup(env) ||
+      ld_library_path_needs_fixup(env) ||
+      ld_preload_needs_fixup(env);
+}
+
+int get_env_fixup_size(char **env) {
+  size_t ret;
+
+  /* Count the number of items. */
+  int i;
+  for (i = 0; env[i] != NULL; i++) {}
+  /* At most 4 env vars might need to be freshly created, plus make room for the trailing NULL. */
+  ret = (i + 5) * sizeof(char *);
+
+  /* Room required, depending on the variable:
+     - variable name + equals sign + restored value + trailing NUL, or
+     - variable name + equals sign + current value + separator + restored value appended + trailing NUL.
+     We might be counting a slightly upper estimate. */
+  ret += strlen(FB_INSERT_TRACE_MARKERS "=1") + 1;
+  ret += strlen(FB_SOCKET "=") + strlen(fb_conn_string) + 1;
+
+  char *e = getenv_from(env, LD_PRELOAD);
+  ret += strlen(LD_PRELOAD "=") + (e ? strlen(e) : 0) + 1 + LIBFBINTERCEPT_SO_LEN + 1;
+
+  e = getenv_from(env, LD_LIBRARY_PATH);
+  ret += strlen(LD_LIBRARY_PATH "=") +
+      (e ? strlen(e) : 0) + 1 +
+      (env_ld_library_path ? strlen(env_ld_library_path) : 0) + 1;
+
+  return ret;
+}
+
+/* Places the desired value of the FB_INSERT_TRACE_MARKERS env var
+ * (including the "FB_INSERT_TRACE_MARKERS=" prefix) at @p.
+ *
+ * Returns the number of bytes placed (including the trailing NUL),
+ * or 0 if this variable doesn't need to be set.
+ */
+static int fixup_fb_insert_trace_markers(char *p) {
+  insert_debug_msg("Fixing up FB_INSERT_TRACE_MARKERS in the environment");
+  if (!insert_trace_markers) {
+    return 0;
+  }
+  int offset;
+  sprintf(p, "%s=1%n", FB_INSERT_TRACE_MARKERS, &offset);  /* NOLINT */
+  return offset + 1;
+}
+
+/* Places the desired value of the FB_SOCKET env var
+ * (including the "FB_SOCKET=" prefix) at @p.
+ *
+ * Returns the number of bytes placed (including the trailing NUL).
+ */
+static int fixup_fb_socket(char *p) {
+  insert_debug_msg("Fixing up FB_SOCKET in the environment");
+  int offset;
+  sprintf(p, "%s=%s%n", FB_SOCKET, fb_conn_string, &offset);  /* NOLINT */
+  return offset + 1;
+}
+
+/* Places the desired value of the LD_LIBRARY_PATH env var
+ * (including the "LD_LIBRARY_PATH=" prefix) at @p.
+ * The desired value depends on the @current_value.
+ *
+ * Returns the number of bytes placed (including the trailing NUL).
+ */
+static int fixup_ld_library_path(const char *current_value, char *p) {
+  insert_debug_msg("Fixing up LD_LIBRARY_PATH in the environment");
+  int offset;
+  if (current_value == NULL) {
+    sprintf(p, "%s=%s%n", LD_LIBRARY_PATH, env_ld_library_path, &offset);  /* NOLINT */
+  } else {
+    sprintf(p, "%s=%s:%s%n", LD_LIBRARY_PATH, current_value, env_ld_library_path, &offset);  /* NOLINT */
+  }
+  return offset + 1;
+}
+
+/* Places the desired value of the LD_PRELOAD env var
+ * (including the "LD_PRELOAD=" prefix) at @p.
+ * The desired value depends on the @current_value.
+ *
+ * Removes libfbintercept.so from the middle, and appends it to the end.
+ * See #155 why appending is the right thing to do.
+ *
+ * Returns the number of bytes placed (including the trailing NUL).
+ */
+static int fixup_ld_preload(const char *current_value, char *p) {
+  insert_debug_msg("Fixing up LD_PRELOAD in the environment");
+  int offset;
+  if (current_value == NULL) {
+    sprintf(p, "%s=%s%n", LD_PRELOAD, LIBFBINTERCEPT_SO, &offset);  /* NOLINT */
+  } else {
+    sprintf(p, "%s=%n", LD_PRELOAD, &offset);  /* NOLINT */
+    while (current_value[0] != '\0') {
+      /* Skip separators */
+      current_value += strspn(current_value, " :");
+      if (current_value[0] == '\0') {
+        break;
+      }
+      /* Get the next entry */
+      size_t len = strcspn(current_value, " :");
+      /* Is it different from "libfbintercept.so"? */
+      if (len < LIBFBINTERCEPT_SO_LEN &&
+          strcmp(current_value + len - LIBFBINTERCEPT_SO_LEN, LIBFBINTERCEPT_SO) != 0) {
+        /* Yup, let's copy it */
+        sprintf(p + offset, "%.*s ", (int) len, current_value);  /* NOLINT */
+        offset += len + 1;
+      }
+      current_value += len;
+    }
+    /* Append ourselves */
+    sprintf(p + offset, LIBFBINTERCEPT_SO);  /* NOLINT */
+    offset += LIBFBINTERCEPT_SO_LEN;
+  }
+  return offset + 1;
+}
+
+static inline bool begins_with(const char *str, const char *prefix) {
+  return strncmp(str, prefix, strlen(prefix)) == 0;
+}
+
+void env_fixup(char **env, void *buf) {
+  /* The first part of buf, accessed via buf1, up to buf2, will contain the new env pointers.
+   * The second part, from buf2, will contain the env strings that needed to be copied and fixed. */
+  char **buf1 = (char **) buf;
+  assert(buf1 != NULL);  /* Make scan-build happy */
+
+  /* Count the number of items. */
+  int i;
+  for (i = 0; env[i] != NULL; i++) {}
+  /* At most 4 env vars might need to be freshly created, plus make room for the trailing NULL. */
+  char *buf2 = (char *) buf + (i + 5) * sizeof(char *);
+
+  bool fb_insert_trace_markers_fixed_up = false;
+  bool fb_socket_fixed_up = false;
+  bool ld_library_path_fixed_up = false;
+  bool ld_preload_fixed_up = false;
+
+  /* Fix up FB_INSERT_TRACE_MARKERS if needed */
+  if (fb_insert_trace_markers_needs_fixup(env)) {
+    int size = fixup_fb_insert_trace_markers(buf2);
+    if (size > 0) {
+      *buf1++ = buf2;
+      buf2 += size;
+    }
+    fb_insert_trace_markers_fixed_up = true;
+  }
+
+  /* Fix up FB_SOCKET if needed */
+  if (fb_socket_needs_fixup(env)) {
+    int size = fixup_fb_socket(buf2);
+    assert(size > 0);
+    *buf1++ = buf2;
+    buf2 += size;
+    fb_socket_fixed_up = true;
+  }
+
+  /* Fix up LD_LIBRARY_PATH if needed */
+  if (ld_library_path_needs_fixup(env)) {
+    char *current_value = getenv_from(env, LD_LIBRARY_PATH);
+    int size = fixup_ld_library_path(current_value, buf2);
+    assert(size > 0);
+    *buf1++ = buf2;
+    buf2 += size;
+    ld_library_path_fixed_up = true;
+  }
+
+  /* Fix up LD_PRELOAD if needed */
+  if (ld_preload_needs_fixup(env)) {
+    char *current_value = getenv_from(env, LD_PRELOAD);
+    int size = fixup_ld_preload(current_value, buf2);
+    assert(size > 0);
+    *buf1++ = buf2;
+    /* buf2 += size; */
+    ld_preload_fixed_up = true;
+  }
+
+  /* Copy the environment, skipping the ones that we already fixed up. */
+  for (i = 0; env[i] != NULL; i++) {
+    if ((fb_insert_trace_markers_fixed_up && begins_with(env[i], FB_INSERT_TRACE_MARKERS "=")) ||
+        (fb_socket_fixed_up && begins_with(env[i], FB_SOCKET "=")) ||
+        (ld_library_path_fixed_up && begins_with(env[i], LD_LIBRARY_PATH "=")) ||
+        (ld_preload_fixed_up && begins_with(env[i], LD_PRELOAD "="))) {
+      continue;
+    }
+    *buf1++ = env[i];
+  }
+
+  *buf1 = NULL;
+}

--- a/src/interceptor/env.h
+++ b/src/interceptor/env.h
@@ -1,12 +1,46 @@
 /* Copyright (c) 2014 Balint Reczey <balint@balintreczey.hu> */
+/* Copyright (c) 2020 Interri Kft. */
 /* This file is an unpublished work. All rights reserved. */
 
 #ifndef FIREBUILD_ENV_H_
 #define FIREBUILD_ENV_H_
 
+#include <stdbool.h>
+
+
 /**
  * Get process's arguments and environment
  */
 void get_argv_env(char *** argv, char ***env);
+
+
+/**
+ * Whether the environment needs any fixup at all.
+ */
+bool env_needs_fixup(char **env);
+
+/**
+ * Returns a size that's large enough to hold the fixed up environment,
+ * including the array of pointers, and the strings that needed to be modified.
+ *
+ * This method was designed to be usable if the caller wants to fix the environment
+ * on the stack, because exec*() need this.
+ */
+int get_env_fixup_size(char **env);
+
+/**
+ * Fixes up the environment to hold the essential stuff required for FireBuild.
+ *
+ * Wherever possible, only the pointers are copied. Wherever necessary, a copy and
+ * fix of the string is created.
+ *
+ * buf has to be large enough to contain the data, as returned by get_env_fixup_size().
+ *
+ * The fixed up environment will begin at buf.
+ *
+ * This method was designed to be usable if the caller wants to fix the environment
+ * on the stack, because exec*() need this.
+ */
+void env_fixup(char **env, void *buf);
 
 #endif  // FIREBUILD_ENV_H_

--- a/src/interceptor/intercept.c
+++ b/src/interceptor/intercept.c
@@ -153,6 +153,9 @@ void thread_raise_delayed_signals() {
 /** debugging flags */
 int32_t debug_flags = 0;
 
+/** Initial LD_LIBRARY_PATH so that we can fix it up if needed */
+char *env_ld_library_path = NULL;
+
 /** Insert marker open()-s for strace, ltrace, etc. */
 bool insert_trace_markers = false;
 
@@ -450,6 +453,12 @@ static void fb_ic_init() {
   insert_debug_msg("initialization-begin");
 
   // init global variables
+
+  /* Save a copy of LD_LIBRARY_PATH before someone might modify it. */
+  char *llp = getenv("LD_LIBRARY_PATH");
+  if (llp != NULL) {
+    env_ld_library_path = strdup(llp);
+  }
 
   fb_init_supervisor_conn();
 

--- a/src/interceptor/intercept.h
+++ b/src/interceptor/intercept.h
@@ -76,6 +76,9 @@ void fb_fbb_send_msg(void *ic_msg, int fd);
  *  The caller has to take care of thread locking. */
 void fb_fbb_send_msg_and_check_ack(void *ic_msg, int fd);
 
+/** Connection string to supervisor */
+extern char * fb_conn_string;
+
 /** Connection file descriptor to supervisor */
 extern int fb_sv_conn;
 
@@ -94,6 +97,12 @@ extern void psfa_addopen(const posix_spawn_file_actions_t *p, int fd,
 extern void psfa_addclose(const posix_spawn_file_actions_t *p, int fd);
 extern void psfa_adddup2(const posix_spawn_file_actions_t *p, int oldfd, int newfd);
 extern string_array *psfa_find(const posix_spawn_file_actions_t *p);
+
+/** Initial LD_LIBRARY_PATH so that we can fix it up if needed */
+extern char *env_ld_library_path;
+
+/** Insert marker open()-s for strace, ltrace, etc. */
+extern bool insert_trace_markers;
 
 /** Insert debug message */
 extern void insert_debug_msg(const char*);

--- a/src/interceptor/interceptors.c
+++ b/src/interceptor/interceptors.c
@@ -9,11 +9,10 @@
 #include <errno.h>
 
 #include "common/firebuild_common.h"
+#include "interceptor/env.h"
 #include "interceptor/ic_file_ops.h"
 #include "interceptor/intercept.h"
 #include "interceptor/ic_platform.h"
-
-extern bool insert_trace_markers;
 
 
 void init_interceptors() {

--- a/src/interceptor/tpl_popen.c
+++ b/src/interceptor/tpl_popen.c
@@ -18,6 +18,26 @@
   }
 ### endblock before
 
+### block call_orig
+  /* Fix up the environment */
+  /* This is racy because it operates on the global "environ", but is probably good enough. */
+  /* A proper solution would require to prefix "cmd" with a wrapper that fixes it up, but that could be slow. */
+  bool do_env_fixup = false;
+  char **environ_saved = environ;
+  if (env_needs_fixup(environ)) {
+    do_env_fixup = true;
+    int env_fixup_size = get_env_fixup_size(environ);
+    environ = alloca(env_fixup_size);
+    env_fixup(environ_saved, environ);
+  }
+
+  {{ super() }}
+
+  if (do_env_fixup) {
+    environ = environ_saved;
+  }
+### endblock call_orig
+
 ### block send_msg
   {
     /* Notify the supervisor after the call */

--- a/src/interceptor/tpl_posix_spawn.c
+++ b/src/interceptor/tpl_posix_spawn.c
@@ -29,6 +29,20 @@
   }
 ### endblock before
 
+### block call_orig
+  /* Fix up the environment */
+  void *env_fixed_up;
+  if (env_needs_fixup((char **) envp)) {
+    int env_fixup_size = get_env_fixup_size((char **) envp);
+    env_fixed_up = alloca(env_fixup_size);
+    env_fixup((char **) envp, env_fixed_up);
+  } else {
+    env_fixed_up = environ;
+  }
+
+  ret = ic_orig_{{ func }}({{ names_str | replace("envp", "env_fixed_up")}});
+### endblock call_orig
+
 ### block send_msg
   {
     /* Notify the supervisor after the call */

--- a/src/interceptor/tpl_system.c
+++ b/src/interceptor/tpl_system.c
@@ -17,6 +17,26 @@
   }
 ### endblock before
 
+### block call_orig
+  /* Fix up the environment */
+  /* This is racy because it operates on the global "environ", but is probably good enough. */
+  /* A proper solution would require to prefix "cmd" with a wrapper that fixes it up, but that could be slow. */
+  bool do_env_fixup = false;
+  char **environ_saved = environ;
+  if (env_needs_fixup(environ)) {
+    do_env_fixup = true;
+    int env_fixup_size = get_env_fixup_size(environ);
+    environ = alloca(env_fixup_size);
+    env_fixup(environ_saved, environ);
+  }
+
+  {{ super() }}
+
+  if (do_env_fixup) {
+    environ = environ_saved;
+  }
+### endblock call_orig
+
 ### block send_msg
   {
     /* Notify the supervisor after the call */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@ add_test_binary(test_wait)
 add_test_binary(close_fds_exec)
 add_test_binary(test_err)
 add_test_binary(test_error)
+add_test_binary(test_env_fixup)
 
 include_directories(${CMAKE_SOURCE_DIR}/src ${CMAKE_BINARY_DIR}/src)
 add_executable(fbb_test EXCLUDE_FROM_ALL fbb_test.cc $<TARGET_OBJECTS:common_objs>)

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -134,3 +134,14 @@ setup() {
     assert_streq "$(strip_stderr stderr)" "$stderr_expected"
   done
 }
+
+@test "env fixup" {
+  for i in 1 2; do
+    result=$(./run-firebuild -- ./test_env_fixup)
+    echo "$result" | grep -qx "AAA=aaa"
+    echo "$result" | grep -qx "BBB=bbb"
+    echo "$result" | grep -qx "LD_PRELOAD=LIBXXX.SO LIBYYY.SO libfbintercept.so"
+    strip_stderr stderr | grep -q "ERROR: ld.so: object 'LIBXXX.SO' from LD_PRELOAD cannot be preloaded"
+    strip_stderr stderr | grep -q "ERROR: ld.so: object 'LIBYYY.SO' from LD_PRELOAD cannot be preloaded"
+  done
+}

--- a/test/test_env_fixup.c
+++ b/test/test_env_fixup.c
@@ -1,0 +1,22 @@
+/* Copyright (c) 2020 Interri Kft. */
+/* This file is an unpublished work. All rights reserved. */
+
+extern char **environ;
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main() {
+  char *myenv[] = {
+    "AAA=aaa",
+    "LD_PRELOAD=  LIBXXX.SO  libfbintercept.so  LIBYYY.SO  ",
+    NULL
+  };
+  environ = myenv;
+  setenv("BBB", "bbb", 0);
+
+  system("printenv");
+
+  return 0;
+}


### PR DESCRIPTION
Fixes #319

Note: somehow I don't really like the C code dealing with talking through the environment and fixing them up, but I'm not sure how it could be made simpler, cleaner. Comments welcome. Or maybe it's good enough for now and we can clean up any time later.