### PR TITLE
supervisor: Fix queueing an execed process

### DIFF
--- a/src/firebuild/firebuild.cc
+++ b/src/firebuild/firebuild.cc
@@ -240,6 +240,7 @@ void proc_new_process_msg(const void *fbb_buf, uint32_t ack_id, int fd_conn,
                 ic_msg, parent, fds);
         proc_tree->QueueExecChild(parent->pid(), fd_conn, proc);
         *new_proc = proc;
+        return;
       }
     } else if (!parent && ppid != getpid()) {
       /* Locate the parent in case of system/popen/posix_spawn, but not


### PR DESCRIPTION
Please take a thorough look to see if this is what you intended.

I haven't tested the code, triggering that code path would require nontrivial changes to the code.

It just doesn't look good: we create a new ExecedProcess, store it in `new_proc`, and then let the code continue below to the `/* Add the ExecedProcess. */` which creates yet another ExecedProcess and overrides `new_proc` with it.