### PR TITLE
interceptor: Insert marker about the parent at fork() and pthread_create()

### DIFF
--- a/src/interceptor/CMakeLists.txt
+++ b/src/interceptor/CMakeLists.txt
@@ -25,6 +25,7 @@ add_custom_command (
   tpl_popen.c
   tpl_posix_spawn.c
   tpl_posix_spawn_file_actions.c
+  tpl_pthread_create.c
   tpl_read.c
   tpl_readlink.c
   tpl_signal.c

--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -1064,7 +1064,7 @@ generate("int", "clone", "int (*fn)(void *), void *stack, int flags, void *arg, 
          before_lines=["(void) fn;     /* seemingly unused, actually used via __builtin_apply_args */",
                        "(void) stack;  /* seemingly unused, actually used via __builtin_apply_args */"])
 generate("int", "pthread_create", "pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void *), void *arg",
-         tpl="marker_only")
+         tpl="pthread_create")
 
 # Intercept the wait family
 # Need to wait for the supervisor to ACK that it has processed what the child had done

--- a/src/interceptor/intercept.h
+++ b/src/interceptor/intercept.h
@@ -202,6 +202,7 @@ inline void thread_signal_danger_zone_leave() {
 
 extern void fb_ic_load() __attribute__((constructor));
 extern void handle_exit(const int status);
+void *pthread_start_routine_wrapper(void *routine_and_arg);
 extern int __libc_start_main(int (*main)(int, char **, char **),
                              int argc, char **ubp_av,
                              void (*init)(void), void (*fini)(void),

--- a/src/interceptor/tpl_pthread_create.c
+++ b/src/interceptor/tpl_pthread_create.c
@@ -1,0 +1,25 @@
+{# ------------------------------------------------------------------ #}
+{# Copyright (c) 2020 Interri Kft.                                    #}
+{# This file is an unpublished work. All rights reserved.             #}
+{# ------------------------------------------------------------------ #}
+{# Template for pthread_create, inherited from marker_only.           #}
+{# Insert another trace markers, telling the pid.                     #}
+{# ------------------------------------------------------------------ #}
+### extends "tpl_marker_only.c"
+
+{% set msg = None %}
+{% set global_lock = False %}
+
+### block no_intercept
+  i_am_intercepting = false;
+### endblock no_intercept
+
+### block call_orig
+  /* Need to pass two pointers using one. Allocate room on the heap,
+   * placing it on the stack might not live long enough.
+   * Will be free()d in pthread_start_routine_wrapper(). */
+  void **routine_and_arg = malloc(2 * sizeof(void *));
+  routine_and_arg[0] = start_routine;
+  routine_and_arg[1] = arg;
+  ret = ic_orig_pthread_create(thread, attr, pthread_start_routine_wrapper, routine_and_arg);
+### endblock call_orig


### PR DESCRIPTION
Note: A similar trick for `main()` was eliminated in #318 because firefox's compilation (rust/cargo) didn't like it; not sure why.

With this new change, firefox is compiling fine (well, maybe rust/cargo just doesn't do multi-threading).

The newly logged information is super convenient to have, will speed up debugging. However, can be already found in the strace logs (e.g. grep all the files to see which one ended up doing a `clone()` with the given PID or TID as the result).

So I'm not sure if you'll like it.

Or maybe I can make the extra hop via the wrapper conditional to `insert_trace_marks`, shall I?