### PR TITLE
supervisor: Don't blacklist apps that write to stdout

### DIFF
--- a/etc/firebuild.conf
+++ b/etc/firebuild.conf
@@ -20,10 +20,7 @@ processes = {
   // can't be cached and shortcutted either.
   blacklist = [
     // orchestrating tools that compare timestamps
-    "make", "ninja",
-    // temprorary until stdin/stdout and pipes are handled
-    "sort", "uniq", "find", "awk", "gawk", "mawk",
-    "glib-compile-resources", "g-ir-compiler", "python3.7"
+    "make", "ninja"
   ];
 
   // Processes that we could cache and shortcut, but prefer not to (for example


### PR DESCRIPTION
Caching them is disabled automatically.