### PR TITLE
supervisor: Use iterator and not at() to find items in collections

### DIFF
--- a/src/firebuild/process.h
+++ b/src/firebuild/process.h
@@ -135,10 +135,11 @@ class Process {
   void sum_rusage(int64_t *sum_utime_u, int64_t *sum_stime_u);
   virtual void exit_result(int status, int64_t utime_u, int64_t stime_u);
   std::shared_ptr<FileFD> get_fd(int fd) {
-    try {
-      return fds_->at(fd);
-    } catch (const std::out_of_range& oor) {
+    assert(fds_);
+    if (fd < 0 || static_cast<unsigned int>(fd) >= fds_->size()) {
       return nullptr;
+    } else {
+      return (*fds_)[fd];
     }
   }
   std::shared_ptr<std::vector<std::shared_ptr<FileFD>>> fds() {return fds_;}

--- a/src/firebuild/process_tree.h
+++ b/src/firebuild/process_tree.h
@@ -76,9 +76,10 @@ class ProcessTree {
   void export_profile2dot(FILE* stream);
   ExecedProcess* root() {return root_;}
   Process* pid2proc(int pid) {
-    try {
-      return pid2proc_.at(pid);
-    } catch (const std::out_of_range& oor) {
+    auto it = pid2proc_.find(pid);
+    if (it != pid2proc_.end()) {
+      return it->second;
+    } else {
       return NULL;
     }
   }
@@ -97,30 +98,34 @@ class ProcessTree {
     ppid2pending_parent_ack_[ppid] = {ack, sock};
   }
   const fork_child_sock* Pid2ForkChildSock(const int pid) {
-    try {
-      return &pid2fork_child_sock_.at(pid);
-    } catch (const std::out_of_range& oor) {
+    auto it = pid2fork_child_sock_.find(pid);
+    if (it != pid2fork_child_sock_.end()) {
+      return &it->second;
+    } else {
       return nullptr;
     }
   }
   const exec_child_sock* Pid2ExecChildSock(const int pid) {
-    try {
-      return &pid2exec_child_sock_.at(pid);
-    } catch (const std::out_of_range& oor) {
+    auto it = pid2exec_child_sock_.find(pid);
+    if (it != pid2exec_child_sock_.end()) {
+      return &it->second;
+    } else {
       return nullptr;
     }
   }
   const exec_child_sock* Pid2PosixSpawnChildSock(const int pid) {
-    try {
-      return &pid2posix_spawn_child_sock_.at(pid);
-    } catch (const std::out_of_range& oor) {
+    auto it = pid2posix_spawn_child_sock_.find(pid);
+    if (it != pid2posix_spawn_child_sock_.end()) {
+      return &it->second;
+    } else {
       return nullptr;
     }
   }
   const pending_parent_ack* PPid2ParentAck(const int ppid) {
-    try {
-      return &ppid2pending_parent_ack_.at(ppid);
-    } catch (const std::out_of_range& oor) {
+    auto it = ppid2pending_parent_ack_.find(ppid);
+    if (it != ppid2pending_parent_ack_.end()) {
+      return &it->second;
+    } else {
       return nullptr;
     }
   }


### PR DESCRIPTION
This avoids throwing an exception when the item is not found and is thus
faster.