### PR TITLE
supervisor: Duplicate shared pointers of FileFDs less often

### DIFF
--- a/src/firebuild/file_fd.h
+++ b/src/firebuild/file_fd.h
@@ -60,6 +60,7 @@ class FileFD {
       read_(false), written_(false), open_(true), origin_fd_(NULL),
       filename_(f), opened_by_(p) {}
   FileFD(FileFD&) = default;
+  FileFD(const FileFD&) = default;
   FileFD& operator= (const FileFD&) = default;
   int last_err() {return last_err_;}
   void set_last_err(int err) {last_err_ = err;}
@@ -67,7 +68,7 @@ class FileFD {
   Process * opened_by() {return opened_by_;}
   bool open() {return open_;}
   void set_open(bool o) {open_ = o;}
-  bool cloexec() {return curr_flags_ & O_CLOEXEC;}
+  bool cloexec() const {return curr_flags_ & O_CLOEXEC;}
   void set_cloexec(bool value) {
     if (value) {
       curr_flags_ |= O_CLOEXEC;
@@ -78,7 +79,7 @@ class FileFD {
   fd_origin origin_type() {return origin_type_;}
   bool read() {return read_;}
   bool written() {return written_;}
-  const FileName* filename() {return filename_;}
+  const FileName* filename() const {return filename_;}
 
  private:
   int fd_;

--- a/src/firebuild/process.h
+++ b/src/firebuild/process.h
@@ -136,12 +136,12 @@ class Process {
   void update_rusage(int64_t utime_u, int64_t stime_u);
   void sum_rusage(int64_t *sum_utime_u, int64_t *sum_stime_u);
   virtual void exit_result(int status, int64_t utime_u, int64_t stime_u);
-  std::shared_ptr<FileFD> get_fd(int fd) {
+  FileFD* get_fd(int fd) {
     assert(fds_);
     if (fd < 0 || static_cast<unsigned int>(fd) >= fds_->size()) {
       return nullptr;
     } else {
-      return (*fds_)[fd];
+      return (*fds_)[fd].get();
     }
   }
   std::shared_ptr<std::vector<std::shared_ptr<FileFD>>> fds() {return fds_;}


### PR DESCRIPTION
This improves performance a bit, by ~0.4% of firebuild's CPU time.