### PR TITLE
supervisor: Rename children to fork_children

### DIFF
--- a/src/firebuild/forked_process.cc
+++ b/src/firebuild/forked_process.cc
@@ -17,7 +17,7 @@ ForkedProcess::ForkedProcess(const int pid, const int ppid,
   // add as fork child of parent
   if (parent) {
     exec_point_ = parent->exec_point();
-    parent->children().push_back(this);
+    parent->fork_children().push_back(this);
   } else {
     fb_error("impossible: Process without known fork parent\n");
   }

--- a/src/firebuild/process.h
+++ b/src/firebuild/process.h
@@ -107,8 +107,8 @@ class Process {
   bool posix_spawn_pending() {return posix_spawn_pending_;}
   void set_exec_child(Process *p) {exec_child_ = p;}
   Process* exec_child() const {return exec_child_;}
-  std::vector<Process*>& children() {return children_;}
-  const std::vector<Process*>& children() const {return children_;}
+  std::vector<Process*>& fork_children() {return fork_children_;}
+  const std::vector<Process*>& fork_children() const {return fork_children_;}
   void set_system_child(ExecedProcess *proc) {system_child_ = proc;}
   ExecedProcess *system_child() const {return system_child_;}
   void set_expected_child(ExecedProcessEnv *ec) {
@@ -392,7 +392,7 @@ class Process {
   /** Sum of user and system time in microseconds for all forked and exec()-ed
       children */
   int64_t aggr_time_ = 0;
-  std::vector<Process*> children_;  ///< children of the process
+  std::vector<Process*> fork_children_;  ///< children of the process
   /// the latest system() child
   ExecedProcess *system_child_ {NULL};
   /// for popen()ed children: client fd -> process mapping

--- a/src/firebuild/process_tree.cc
+++ b/src/firebuild/process_tree.cc
@@ -71,8 +71,8 @@ profile_collect_cmds(const Process &p,
     }
     (*cmds)[ec->args()[0]].count += 1;
   }
-  for (auto& child : p.children()) {
-    profile_collect_cmds(*child, cmds, ancestors);
+  for (auto& fork_child : p.fork_children()) {
+    profile_collect_cmds(*fork_child, cmds, ancestors);
   }
 }
 
@@ -93,8 +93,8 @@ void ProcessTree::build_profile(const Process &p,
   if (p.exec_child() != NULL) {
     build_profile(*p.exec_child(), ancestors);
   }
-  for (auto& child : p.children()) {
-    build_profile(*child, ancestors);
+  for (auto& fork_child : p.fork_children()) {
+    build_profile(*fork_child, ancestors);
   }
 
   if (first_visited) {


### PR DESCRIPTION
Fixes #421

Since #390 is on hold, I guess we should submit this (it helps code readability anyway) and rebase that one. What do you think?