### PR TITLE
supervisor: Raise error on zero-sized (obj) cache entry

### DIFF
--- a/src/firebuild/obj_cache.cc
+++ b/src/firebuild/obj_cache.cc
@@ -248,6 +248,11 @@ bool ObjCache::retrieve(const Hash &key,
       close(fd);
       return false;
     }
+  } else {
+    fb_error("0-sized cache entry: " + path);
+    assert(st.st_size <= 0);
+    close(fd);
+    return false;
   }
   close(fd);
 


### PR DESCRIPTION
ASAN found this on the capture fd branch:

```checking for getrlimit... =================================================================
ESC[1mESC[31m==43170==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7ff121d0c628 at pc 0x5602e6708653 bp 0x7ffdb63423c0 sp 0x7ffdb63423b0
ESC[1mESC[0mESC[1mESC[34mREAD of size 4 at 0x7ff121d0c628 thread T0ESC[1mESC[0m
    #0 0x5602e6708652 in int flatbuffers::ReadScalar<int>(void const*) /usr/include/flatbuffers/base.h:356
    #1 0x5602e66f54a8 in flatbuffers::Table::GetVTable() const /usr/include/flatbuffers/flatbuffers.h:2252
    #2 0x5602e66f54d5 in flatbuffers::Table::GetOptionalFieldOffset(unsigned short) const /usr/include/flatbuffers/flatbuffers.h:2259
    #3 0x5602e670be39 in flatbuffers::String const* flatbuffers::Table::GetPointer<flatbuffers::String const*>(unsigned short) /usr/include/flatbuffers/flatbuffers.h:2273
    #4 0x5602e6708685 in flatbuffers::String const* flatbuffers::Table::GetPointer<flatbuffers::String const*>(unsigned short) const /usr/include/flatbuffers/flatbuffers.h:2279
    #5 0x5602e66f565c in firebuild::msg::File::path() const /home/ubuntu/firebuild/build/src/firebuild/cache_object_format_generated.h:53
    #6 0x5602e66fd655 in pi_matches_fs /home/ubuntu/firebuild/src/firebuild/execed_process_cacher.cc:306
    #7 0x5602e6702f84 in firebuild::ExecedProcessCacher::find_shortcut(firebuild::ExecedProcess const*, unsigned char**, unsigned long*) /home/ubuntu/firebuild/src/firebuild/execed_process_cacher.cc:420
    #8 0x5602e67071eb in firebuild::ExecedProcessCacher::shortcut(firebuild::ExecedProcess*) /home/ubuntu/firebuild/src/firebuild/execed_process_cacher.cc:572
    #9 0x5602e66df098 in firebuild::ExecedProcess::shortcut() /home/ubuntu/firebuild/src/firebuild/execed_process.cc:283
    #10 0x5602e66817c8 in firebuild::accept_exec_child(firebuild::ExecedProcess*, firebuild::FD, firebuild::ProcessTree*) /home/ubuntu/firebuild/src/firebuild/firebuild.cc:255
    #11 0x5602e6684ebc in proc_new_process_msg /home/ubuntu/firebuild/src/firebuild/firebuild.cc:455
    #12 0x5602e668d8f8 in ic_conn_readcb /home/ubuntu/firebuild/src/firebuild/firebuild.cc:1125
    #13 0x7ff1256dc13e  (/lib/x86_64-linux-gnu/libevent-2.1.so.7+0x2113e)
    #14 0x7ff1256dc87e in event_base_loop (/lib/x86_64-linux-gnu/libevent-2.1.so.7+0x2187e)
    #15 0x5602e6690746 in main /home/ubuntu/firebuild/src/firebuild/firebuild.cc:1378
    #16 0x7ff1257510b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #17 0x5602e6664ffd in _start (/home/ubuntu/firebuild/build/src/firebuild/firebuild+0x1fffd)

ESC[1mESC[32m0x7ff121d0c628 is located 3152 bytes to the right of 336344-byte region [0x7ff121cb9800,0x7ff121d0b9d8)
ESC[1mESC[0mESC[1mESC[35mallocated by thread T0 here:ESC[1mESC[0m
    #0 0x7ff125a2b947 in operator new(unsigned long) (/lib/x86_64-linux-gnu/libasan.so.5+0x10f947)
    #1 0x5602e666c608 in __gnu_cxx::new_allocator<std::__detail::_Hash_node_base*>::allocate(unsigned long, void const*) /usr/include/c++/9/ext/new_allocator.h:114
    #2 0x5602e666c181 in std::allocator_traits<std::allocator<std::__detail::_Hash_node_base*> >::allocate(std::allocator<std::__detail::_Hash_node_base*>&, unsigned long) /usr/include/c++/9/bits/alloc_traits.h:444
    #3 0x5602e666be5e in std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<firebuild::FileName, false> > >::_M_allocate_buckets(unsigned long) /usr/include/c++/9/bits/hashtable_policy.h:2134
    #4 0x5602e666ba93 in std::_Hashtable<firebuild::FileName, firebuild::FileName, std::allocator<firebuild::FileName>, std::__detail::_Identity, std::equal_to<firebuild::FileName>, firebuild::FileNameHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, true, true> >::_M_allocate_buckets(unsigned long) /usr/include/c++/9/bits/hashtable.h:361
    #5 0x5602e666b150 in std::_Hashtable<firebuild::FileName, firebuild::FileName, std::allocator<firebuild::FileName>, std::__detail::_Identity, std::equal_to<firebuild::FileName>, firebuild::FileNameHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, true, true> >::_M_rehash_aux(unsigned long, std::integral_constant<bool, true>) /usr/include/c++/9/bits/hashtable.h:2088
    #6 0x5602e666a66b in std::_Hashtable<firebuild::FileName, firebuild::FileName, std::allocator<firebuild::FileName>, std::__detail::_Identity, std::equal_to<firebuild::FileName>, firebuild::FileNameHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, true, true> >::_M_rehash(unsigned long, unsigned long const&) /usr/include/c++/9/bits/hashtable.h:2067
    #7 0x5602e66696f2 in std::_Hashtable<firebuild::FileName, firebuild::FileName, std::allocator<firebuild::FileName>, std::__detail::_Identity, std::equal_to<firebuild::FileName>, firebuild::FileNameHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, true, true> >::_M_insert_unique_node(unsigned long, unsigned long, std::__detail::_Hash_node<firebuild::FileName, false>*, unsigned long) /usr/include/c++/9/bits/hashtable.h:1713
    #8 0x5602e666863c in std::pair<std::__detail::_Node_iterator<firebuild::FileName, true, false>, bool> std::_Hashtable<firebuild::FileName, firebuild::FileName, std::allocator<firebuild::FileName>, std::__detail::_Identity, std::equal_to<firebuild::FileName>, firebuild::FileNameHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, true, true> >::_M_insert<firebuild::FileName const&, std::__detail::_AllocNode<std::allocator<std::__detail::_Hash_node<firebuild::FileName, false> > > >(firebuild::FileName const&, std::__detail::_AllocNode<std::allocator<std::__detail::_Hash_node<firebuild::FileName, false> > > const&, std::integral_constant<bool, true>, unsigned long) /usr/include/c++/9/bits/hashtable.h:1818
    #9 0x5602e6667e5d in std::__detail::_Insert_base<firebuild::FileName, firebuild::FileName, std::allocator<firebuild::FileName>, std::__detail::_Identity, std::equal_to<firebuild::FileName>, firebuild::FileNameHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, true, true> >::insert(firebuild::FileName const&) /usr/include/c++/9/bits/hashtable_policy.h:824
    #10 0x5602e6667602 in std::unordered_set<firebuild::FileName, firebuild::FileNameHasher, std::equal_to<firebuild::FileName>, std::allocator<firebuild::FileName> >::insert(firebuild::FileName const&) /usr/include/c++/9/bits/unordered_set.h:421
    #11 0x5602e6665940 in firebuild::FileName::Get(char const*, long) /home/ubuntu/firebuild/src/firebuild/file_name.h:89
    #12 0x5602e66f5541 in firebuild::FileName::Get(flatbuffers::String const*) /home/ubuntu/firebuild/src/firebuild/file_name.h:33
    #13 0x5602e670510f in firebuild::ExecedProcessCacher::apply_shortcut(firebuild::ExecedProcess*, firebuild::msg::ProcessInputsOutputs const*) /home/ubuntu/firebuild/src/firebuild/execed_process_cacher.cc:488
    #14 0x5602e67072f8 in firebuild::ExecedProcessCacher::shortcut(firebuild::ExecedProcess*) /home/ubuntu/firebuild/src/firebuild/execed_process_cacher.cc:578
    #15 0x5602e66df098 in firebuild::ExecedProcess::shortcut() /home/ubuntu/firebuild/src/firebuild/execed_process.cc:283
    #16 0x5602e66817c8 in firebuild::accept_exec_child(firebuild::ExecedProcess*, firebuild::FD, firebuild::ProcessTree*) /home/ubuntu/firebuild/src/firebuild/firebuild.cc:255
    #17 0x5602e6684ebc in proc_new_process_msg /home/ubuntu/firebuild/src/firebuild/firebuild.cc:455
    #18 0x5602e668d8f8 in ic_conn_readcb /home/ubuntu/firebuild/src/firebuild/firebuild.cc:1125
    #19 0x7ff1256dc13e  (/lib/x86_64-linux-gnu/libevent-2.1.so.7+0x2113e)

SUMMARY: AddressSanitizer: heap-buffer-overflow /usr/include/flatbuffers/base.h:356 in int flatbuffers::ReadScalar<int>(void const*)
Shadow bytes around the buggy address:


```