### PR TITLE
supervisor: Add TRACKX macro to print a variable when leaving a function

### DIFF
--- a/src/firebuild/debug.cc
+++ b/src/firebuild/debug.cc
@@ -185,7 +185,7 @@ int32_t parse_debug_flags(const std::string& str) {
 }
 
 #ifndef NDEBUG
-int MethodTracker::level_ = 0;
+int method_tracker_level = 0;
 #endif
 
 }  // namespace firebuild

--- a/src/firebuild/debug.h
+++ b/src/firebuild/debug.h
@@ -10,6 +10,8 @@
 #include <string>
 #include <vector>
 
+#include "firebuild/cxx_lang_utils.h"
+
 namespace firebuild {
 
 /** Print error message */
@@ -97,48 +99,154 @@ std::string d(const std::vector<std::string>& arr,
 /** Get a human-readable timestamp according to local time. */
 std::string pretty_timestamp();
 
+
 #ifdef NDEBUG
-#define TRACK(flag, fmt, ...)
+#define TRACK(...)
+#define TRACKX(...)
 #else
-/* Track entering/leaving the function (or any brace-block of code)
- * if either "func" or any of the given flags is being debugged. */
+/* Global, shared across MethodTracker and all MethodTrackerX<T>s, for nice indentation */
+extern int method_tracker_level;
+
+/**
+ * Track entering and leaving a function (or any brace-block of code).
+ * Print some variables when entering.
+ *
+ * @param flag Do the logging if FB_DEBUG_FUNC or any of these debug flags specified here is enabled
+ * @param fmt printf format string, may be empty
+ * @param ... The additional parameters for printf
+ */
 #define TRACK(flag, fmt, ...) \
-  firebuild::MethodTracker method_tracker(flag, __func__, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
+  firebuild::MethodTracker method_tracker(__func__, __FILE__, __LINE__, flag, fmt, ##__VA_ARGS__)
 
 class MethodTracker {
  public:
-  MethodTracker(int flag, const char *func, const char *file, int line, const char *fmt, ...)
+  MethodTracker(const char *func, const char *file, int line, int flag, const char *fmt, ...)
       __attribute__((format(printf, 6, 7)))
-      : flag_(flag | FB_DEBUG_FUNC), func_(func) {
+      : func_(func), file_(file), line_(line), flag_(flag | FB_DEBUG_FUNC) {
     if (FB_DEBUGGING(flag_)) {
-      const char *last_slash = strrchr(file, '/');
+      const char *last_slash = strrchr(file_, '/');
       if (last_slash) {
-        file = last_slash + 1;
+        file_ = last_slash + 1;
       }
       char buf[1024];
-      int run1 = snprintf(buf, sizeof(buf), "%*s-> %s()  [%s:%d]  ",
-                          2 * level_, "", func, file, line);
+      int offset = snprintf(buf, sizeof(buf), "%*s-> %s()  (%s:%d)%s",
+                            2 * method_tracker_level, "", func_, file_, line_,
+                            fmt[0] ? "  " : "");
       va_list ap;
       va_start(ap, fmt);
-      vsnprintf(buf + run1, sizeof(buf) - run1, fmt, ap);
+      vsnprintf(buf + offset, sizeof(buf) - offset, fmt, ap);
       va_end(ap);
       FB_DEBUG(flag_, buf);
-      level_++;
+      method_tracker_level++;
     }
   }
   ~MethodTracker() {
     if (FB_DEBUGGING(flag_)) {
-      level_--;
+      method_tracker_level--;
       char buf[1024];
-      snprintf(buf, sizeof(buf), "%*s<- %s()", 2 * level_, "", func_.c_str());
+      snprintf(buf, sizeof(buf), "%*s<- %s()  (%s:%d)",
+               2 * method_tracker_level, "", func_, file_, line_);
       FB_DEBUG(flag_, buf);
     }
   }
 
  private:
+  const char *func_;
+  const char *file_;
+  int line_;
   int flag_;
-  std::string func_;
-  static int level_;
+
+  DISALLOW_COPY_AND_ASSIGN(MethodTracker);
+};
+
+/**
+ * Track entering and leaving a function (or any brace-block of code).
+ * Print one variable both when entering and leaving.
+ * Print some more variables when entering.
+ *
+ * The variable to be printed when leaving the block (obj_ptr) has to have a corresponding global
+ * std::string d(classname *obj_ptr, int level) debugging method, which will be used to format it.
+ * The variable is remembered via its pointer, so if you reassign it in the function body then you
+ * can't print it upon exit.
+ *
+ * Having to pass the classsname of obj_ptr is a technical necessity, remove it if you know how to.
+ *
+ * @param flag Do the logging if FB_DEBUG_FUNC or any of these debug flags specified here is enabled
+ * @param print_obj_on_enter Whether to log obj_ptr when entering the block
+ * @param print_obj_on_leave Whether to log obj_ptr when leaving the block
+ * @param classname The classname of obj_ptr, without 'const', or '*' for pointer
+ * @param obj_ptr The object to print on entering of leaving, of type 'classname *'.
+ * @param fmt printf format string for the additional variables to log when entering, may be empty
+ * @param ... The additional parameters for printf
+ */
+#define TRACKX(flag, print_obj_on_enter, print_obj_on_leave, classname, obj_ptr, fmt, ...) \
+  /* Find the address of the correct ovedloaded d() method belonging to obj_ptr. */ \
+  /* Needs to happen in the context of the macro's caller, because debug.h doesn't see the */ \
+  /* specific d() method, so d() inside MethodTrackerX() would pick the one taking a boolean. */ \
+  std::string (*resolved_d)(const classname *, int) = &firebuild::d; \
+  firebuild::MethodTrackerX<classname> method_tracker(__func__, __FILE__, __LINE__, \
+                                                      flag, \
+                                                      print_obj_on_enter, print_obj_on_leave, \
+                                                      #obj_ptr, obj_ptr, resolved_d, \
+                                                      fmt, ##__VA_ARGS__)
+
+template <typename T>
+class MethodTrackerX {
+ public:
+  MethodTrackerX(const char *func, const char *file, int line,
+                 int flag, bool print_obj_on_enter, bool print_obj_on_leave,
+                 const char *obj_name, const T *obj_ptr, std::string (*resolved_d)(const T *, int),
+                 const char *fmt, ...)
+      __attribute__((format(printf, 11, 12)))
+      : func_(func), file_(file), line_(line),
+        flag_(flag | FB_DEBUG_FUNC), print_obj_on_leave_(print_obj_on_leave),
+        obj_name_(obj_name), obj_ptr_(obj_ptr), resolved_d_(resolved_d) {
+    if (FB_DEBUGGING(flag_)) {
+      const char *last_slash = strrchr(file_, '/');
+      if (last_slash) {
+        file_ = last_slash + 1;
+      }
+      char buf[1024];
+      int offset = snprintf(buf, sizeof(buf), "%*s-> %s()  (%s:%d)%s",
+                            2 * method_tracker_level, "", func_, file_, line_,
+                            print_obj_on_enter || fmt[0] ? "  " : "");
+      if (print_obj_on_enter) {
+        offset += snprintf(buf + offset, sizeof(buf) - offset, "%s=%s%s",
+                           obj_name_, ((*resolved_d_)(obj_ptr_, 0)).c_str(), fmt[0] ? ", " : "");
+      }
+      va_list ap;
+      va_start(ap, fmt);
+      vsnprintf(buf + offset, sizeof(buf) - offset, fmt, ap);
+      va_end(ap);
+      FB_DEBUG(flag_, buf);
+      method_tracker_level++;
+    }
+  }
+  ~MethodTrackerX() {
+    if (FB_DEBUGGING(flag_)) {
+      method_tracker_level--;
+      char buf[1024];
+      int offset = snprintf(buf, sizeof(buf), "%*s<- %s()  (%s:%d)",
+                            2 * method_tracker_level, "", func_, file_, line_);
+      if (print_obj_on_leave_) {
+        snprintf(buf + offset, sizeof(buf) - offset, "  %s=%s",
+                 obj_name_, ((*resolved_d_)(obj_ptr_, 0)).c_str());
+      }
+      FB_DEBUG(flag_, buf);
+    }
+  }
+
+ private:
+  const char *func_;
+  const char *file_;
+  int line_;
+  int flag_;
+  bool print_obj_on_leave_;
+  const char *obj_name_;
+  const T *obj_ptr_;
+  std::string (*resolved_d_)(const T *, int);
+
+  DISALLOW_COPY_AND_ASSIGN(MethodTrackerX<T>);
 };
 #endif  /* NDEBUG */
 

--- a/src/firebuild/execed_process.cc
+++ b/src/firebuild/execed_process.cc
@@ -54,8 +54,9 @@ ExecedProcess::ExecedProcess(const int pid, const int ppid,
       sum_utime_u_(0), sum_stime_u_(0), initial_wd_(initial_wd),
       wds_(), failed_wds_(), args_(), env_vars_(), executable_(executable),
       libs_(), file_usages_(), cacher_(NULL), exec_count_(1) {
-  TRACK(FB_DEBUG_PROC, "pid=%d, ppid=%d, initial_wd=%s, executable=%s, parent=%s",
-        pid, ppid, D(initial_wd), D(executable), D(parent));
+  TRACKX(FB_DEBUG_PROC, 0, 1, Process, this,
+         "pid=%d, ppid=%d, initial_wd=%s, executable=%s, parent=%s",
+         pid, ppid, D(initial_wd), D(executable), D(parent));
 
   if (parent != NULL) {
     exec_count_ = parent->exec_count() + 1;
@@ -73,7 +74,7 @@ ExecedProcess::ExecedProcess(const int pid, const int ppid,
  * ExecedProcess in the ProcessTree.
  */
 void ExecedProcess::initialize() {
-  TRACK(FB_DEBUG_PROC, "this=%s", D(this));
+  TRACKX(FB_DEBUG_PROC, 0, 1, Process, this, "");
 
   /* Propagate the opening of the executable and libraries upwards as
    * regular file open events. */
@@ -87,7 +88,7 @@ void ExecedProcess::initialize() {
 }
 
 void ExecedProcess::propagate_exit_status(const int status) {
-  TRACK(FB_DEBUG_PROC, "this=%s, status=%d", D(this), status);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "status=%d", status);
 
   if (parent()) {
     parent()->set_exit_status(status);
@@ -97,8 +98,8 @@ void ExecedProcess::propagate_exit_status(const int status) {
 
 void ExecedProcess::exit_result(const int status, const int64_t utime_u,
                                 const int64_t stime_u) {
-  TRACK(FB_DEBUG_PROC, "this=%s, status=%d, utime_u=%ld, stime_u=%ld",
-        D(this), status, utime_u, stime_u);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "status=%d, utime_u=%ld, stime_u=%ld",
+         status, utime_u, stime_u);
 
   // store results for this process
   Process::exit_result(status, utime_u, stime_u);
@@ -107,7 +108,7 @@ void ExecedProcess::exit_result(const int status, const int64_t utime_u,
 }
 
 void ExecedProcess::do_finalize() {
-  TRACK(FB_DEBUG_PROC, "this=%s", D(this));
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "");
 
   // store data for shortcutting
   if (cacher_ && !was_shortcut() && can_shortcut()) {
@@ -145,7 +146,7 @@ void ExecedProcess::do_finalize() {
  */
 void ExecedProcess::propagate_file_usage(const FileName *name,
                                          const FileUsage &fu_change) {
-  TRACK(FB_DEBUG_PROC, "this=%s, name=%s, fu_change=%s", D(this), D(name), D(fu_change));
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "name=%s, fu_change=%s", D(name), D(fu_change));
 
   FileUsage *fu;
   auto it = file_usages_.find(name);
@@ -175,8 +176,8 @@ bool ExecedProcess::register_file_usage(const FileName *name,
                                         FileAction action,
                                         int flags,
                                         int error) {
-  TRACK(FB_DEBUG_PROC, "this=%s, name=%s, actual_file=%s, flags=%d, error=%d",
-        D(this), D(name), D(actual_file), flags, error);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "name=%s, actual_file=%s, flags=%d, error=%d",
+         D(name), D(actual_file), flags, error);
 
   if (name->is_at_locations(ignore_locations)) {
     FB_DEBUG(FB_DEBUG_FS, "Ignoring file usage: " + d(name));
@@ -225,7 +226,7 @@ bool ExecedProcess::register_file_usage(const FileName *name,
  */
 bool ExecedProcess::register_file_usage(const FileName *name,
                                         FileUsage fu_change) {
-  TRACK(FB_DEBUG_PROC, "this=%s, name=%s, fu_change=%s", D(this), D(name), D(fu_change));
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "name=%s, fu_change=%s", D(name), D(fu_change));
 
   if (name->is_at_locations(ignore_locations)) {
     FB_DEBUG(FB_DEBUG_FS, "Ignoring file usage: " + d(name));
@@ -252,7 +253,7 @@ bool ExecedProcess::register_file_usage(const FileName *name,
  * to the given file.
  */
 bool ExecedProcess::register_parent_directory(const FileName *name) {
-  TRACK(FB_DEBUG_PROC, "this=%s, name=%s", D(this), D(name));
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "name=%s", D(name));
 
   /* name is canonicalized, so just simply strip the last component */
   std::string parent_name = name->to_string();
@@ -271,7 +272,7 @@ bool ExecedProcess::register_parent_directory(const FileName *name) {
 
 /* Find and apply shortcut */
 bool ExecedProcess::shortcut() {
-  TRACK(FB_DEBUG_PROC, "this=%s", D(this));
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "");
 
   if (can_shortcut() && cacher_) {
     return cacher_->shortcut(this);
@@ -287,7 +288,7 @@ bool ExecedProcess::shortcut() {
 }
 
 void ExecedProcess::disable_shortcutting_only_this(const std::string &reason, const Process *p) {
-  TRACK(FB_DEBUG_PROC, "this=%s, reason=%s, source=%s", D(this), D(reason), D(p));
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "reason=%s, source=%s", D(reason), D(p));
 
   if (can_shortcut_) {
     can_shortcut_ = false;

--- a/src/firebuild/fd.cc
+++ b/src/firebuild/fd.cc
@@ -18,7 +18,7 @@ FD FD::open(int fd) {
 }
 
 void FD::close() {
-  TRACK(FB_DEBUG_FD, "this=%s", D(this));
+  TRACKX(FB_DEBUG_FD, 1, 0, FD, this, "");
 
   assert(is_valid());
   fd_to_age_[fd_].opened = false;

--- a/src/firebuild/file.cc
+++ b/src/firebuild/file.cc
@@ -16,18 +16,18 @@ namespace firebuild {
 
 File::File(const FileName* p)
     : mtimes_(), path_(p), exists_(false), hash_() {
-  TRACK(FB_DEBUG_PROC, "this=%s, path=%s", D(this), D(p));
+  TRACKX(FB_DEBUG_PROC, 0, 1, File, this, "path=%s", D(p));
 }
 
 
 int File::set_hash() {
-  TRACK(FB_DEBUG_PROC, "this=%s", D(this));
+  TRACKX(FB_DEBUG_PROC, 0, 1, File, this, "");
 
   return hash_cache->get_hash(path_, &hash_);
 }
 
 int File::update() {
-  TRACK(FB_DEBUG_PROC, "this=%s", D(this));
+  TRACKX(FB_DEBUG_PROC, 1, 1, File, this, "");
 
   if (!this->set_hash()) {
     return -1;
@@ -86,7 +86,7 @@ int File::update() {
 #endif
 
 int File::is_changed() {
-  TRACK(FB_DEBUG_PROC, "this=%s", D(this));
+  TRACKX(FB_DEBUG_PROC, 1, 0, File, this, "");
 
   int i = 0;
   char *tmp_path = strdup(path_->c_str());

--- a/src/firebuild/file_usage.cc
+++ b/src/firebuild/file_usage.cc
@@ -38,7 +38,7 @@ namespace firebuild {
  * @return if the merge caused a change in "this"
  */
 bool FileUsage::merge(const FileUsage& that) {
-  TRACK(FB_DEBUG_PROC, "this=%s, that=%s", D(this), D(that));
+  TRACKX(FB_DEBUG_PROC, 1, 1, FileUsage, this, "that=%s", D(that));
 
   bool changed = false;
   if (initial_state_ == DONTKNOW) {
@@ -73,8 +73,9 @@ bool FileUsage::merge(const FileUsage& that) {
 bool FileUsage::update_from_open_params(const FileName* filename,
                                         FileAction action, int flags, int err,
                                         bool do_read) {
-  TRACK(FB_DEBUG_PROC, "this=%s, filename=%s, action=%s, flags=%d, err=%d, do_read=%s",
-        D(this), D(filename), file_action_to_string(action), flags, err, D(do_read));
+  TRACKX(FB_DEBUG_PROC, 1, 1, FileUsage, this,
+         "filename=%s, action=%s, flags=%d, err=%d, do_read=%s",
+         D(filename), file_action_to_string(action), flags, err, D(do_read));
 
   if (!do_read) {
     if ((action == FILE_ACTION_MKDIR || is_write(flags)) && !err) {

--- a/src/firebuild/firebuild.cc
+++ b/src/firebuild/firebuild.cc
@@ -193,7 +193,7 @@ namespace firebuild {
 
 void accept_exec_child(ExecedProcess* proc, FD fd_conn,
                        ProcessTree* proc_tree) {
-    TRACK(FB_DEBUG_PROC, "proc=%s, fd_conn=%s", D(proc), D(fd_conn));
+    TRACKX(FB_DEBUG_PROC, 1, 1, Process, proc, "fd_conn=%s", D(fd_conn));
 
     FBB_Builder_scproc_resp sv_msg;
     fbb_scproc_resp_init(&sv_msg);
@@ -392,8 +392,8 @@ void proc_ic_msg(const void *fbb_buf,
                  uint32_t ack_num,
                  firebuild::FD fd_conn,
                  firebuild::Process* proc) {
-  TRACK(firebuild::FB_DEBUG_COMM, "fd_conn=%s, tag=%s, ack_num=%d, proc=%s",
-        D(fd_conn), fbb_tag_string(fbb_buf), ack_num, D(proc));
+  TRACKX(firebuild::FB_DEBUG_COMM, 1, 1, firebuild::Process, proc, "fd_conn=%s, tag=%s, ack_num=%d",
+         D(fd_conn), fbb_tag_string(fbb_buf), ack_num);
 
   int tag = *reinterpret_cast<const int *>(fbb_buf);
   assert(proc);

--- a/src/firebuild/forked_process.cc
+++ b/src/firebuild/forked_process.cc
@@ -15,7 +15,7 @@ ForkedProcess::ForkedProcess(const int pid, const int ppid,
                              Process* parent,
                              std::shared_ptr<std::vector<std::shared_ptr<FileFD>>> fds)
     : Process(pid, ppid, parent ? parent->wd() : FileName::Get(""), parent, fds) {
-  TRACK(FB_DEBUG_PROC, "pid=%d, ppid=%d, parent=%s", pid, ppid, D(parent));
+  TRACKX(FB_DEBUG_PROC, 0, 1, Process, this, "pid=%d, ppid=%d, parent=%s", pid, ppid, D(parent));
 
   // add as fork child of parent
   if (parent) {

--- a/src/firebuild/hash.cc
+++ b/src/firebuild/hash.cc
@@ -43,7 +43,7 @@ Hash::HashMapsInitializer Hash::hash_maps_initializer_;
  * Set the binary hash from the given buffer.
  */
 void Hash::set_from_data(const void *data, ssize_t size) {
-  TRACK(FB_DEBUG_HASH, "");
+  TRACKX(FB_DEBUG_HASH, 0, 1, Hash, this, "");
 
   /* xxhash's doc says:
    * "Streaming functions [...] is slower than single-call functions, due to state management."
@@ -70,7 +70,7 @@ void Hash::set_from_data(const void *data, ssize_t size) {
  * @return Whether succeeded
  */
 bool Hash::set_from_fd(int fd, bool *is_dir_out) {
-  TRACK(FB_DEBUG_HASH, "fd=%d", fd);
+  TRACKX(FB_DEBUG_HASH, 0, 1, Hash, this, "fd=%d", fd);
 
   struct stat64 st;
   if (fstat64(fd, &st) == -1) {
@@ -166,7 +166,7 @@ bool Hash::set_from_fd(int fd, bool *is_dir_out) {
  * @return Whether succeeded
  */
 bool Hash::set_from_file(const FileName *filename, bool *is_dir_out) {
-  TRACK(FB_DEBUG_HASH, "filename=%s", D(filename));
+  TRACKX(FB_DEBUG_HASH, 0, 1, Hash, this, "filename=%s", D(filename));
 
   int fd;
 
@@ -199,7 +199,7 @@ bool Hash::set_from_file(const FileName *filename, bool *is_dir_out) {
  * Returns true if succeeded, false if the input is not a valid binary hash.
  */
 bool Hash::set_hash_from_binary(const uint8_t * const binary) {
-  TRACK(FB_DEBUG_HASH, "");
+  TRACKX(FB_DEBUG_HASH, 0, 1, Hash, this, "");
 
   if (binary[sizeof(arr_) - 1] & 0x03) {
     return false;

--- a/src/firebuild/process.cc
+++ b/src/firebuild/process.cc
@@ -27,7 +27,7 @@ Process::Process(const int pid, const int ppid, const FileName *wd,
       pid_(pid), ppid_(ppid), exit_status_(-1), wd_(wd), fds_(fds),
       closed_fds_({}), utime_u_(0), stime_u_(0), aggr_time_(0), fork_children_(),
       expected_child_(), exec_child_(NULL) {
-  TRACK(FB_DEBUG_PROC, "pid=%d, ppid=%d, parent=%s", pid, ppid, D(parent));
+  TRACKX(FB_DEBUG_PROC, 0, 1, Process, this, "pid=%d, ppid=%d, parent=%s", pid, ppid, D(parent));
 
   if (!fds_) {
     fds_ = std::make_shared<std::vector<std::shared_ptr<FileFD>>>();
@@ -82,7 +82,7 @@ void Process::add_filefd(std::shared_ptr<std::vector<std::shared_ptr<FileFD>>> f
 }
 
 std::shared_ptr<std::vector<std::shared_ptr<FileFD>>> Process::pass_on_fds(bool execed) {
-  TRACK(FB_DEBUG_PROC, "this=%s, execed=%s", D(this), D(execed));
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "execed=%s", D(execed));
 
   auto fds = std::make_shared<std::vector<std::shared_ptr<FileFD>>>();
   for (unsigned int i = 0; i < fds_->size(); i++) {
@@ -101,9 +101,9 @@ std::shared_ptr<std::vector<std::shared_ptr<FileFD>>> Process::pass_on_fds(bool 
 
 int Process::handle_open(const int dirfd, const char * const ar_name, const int flags,
                          const int fd, const int error, FD fd_conn, const int ack_num) {
-  TRACK(FB_DEBUG_PROC,
-        "this=%s, dirfd=%d, ar_name=%s, flags=%d, fd=%d, error=%d, fd_conn=%s, ack_num=%d",
-        D(this), dirfd, D(ar_name), flags, fd, error, D(fd_conn), ack_num);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this,
+         "dirfd=%d, ar_name=%s, flags=%d, fd=%d, error=%d, fd_conn=%s, ack_num=%d",
+         dirfd, D(ar_name), flags, fd, error, D(fd_conn), ack_num);
 
   const FileName* name = get_absolute(dirfd, ar_name);
   if (!name) {
@@ -136,7 +136,7 @@ int Process::handle_open(const int dirfd, const char * const ar_name, const int 
 
 /* close that fd if open, silently ignore if not open */
 int Process::handle_force_close(const int fd) {
-  TRACK(FB_DEBUG_PROC, "this=%s, fd=%d", D(this), fd);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "fd=%d", fd);
 
   if (get_fd(fd)) {
     return handle_close(fd, 0);
@@ -145,7 +145,7 @@ int Process::handle_force_close(const int fd) {
 }
 
 int Process::handle_close(const int fd, const int error) {
-  TRACK(FB_DEBUG_PROC, "this=%s, fd=%d, error=%d", D(this), fd, error);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "fd=%d, error=%d", fd, error);
 
   FileFD* file_fd = get_fd(fd);
 
@@ -192,8 +192,8 @@ int Process::handle_close(const int fd, const int error) {
 
 int Process::handle_unlink(const int dirfd, const char * const ar_name,
                            const int flags, const int error) {
-  TRACK(FB_DEBUG_PROC, "this=%s, dirfd=%d, ar_name=%s, flags=%d, error=%d",
-        D(this), dirfd, D(ar_name), flags, error);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "dirfd=%d, ar_name=%s, flags=%d, error=%d",
+         dirfd, D(ar_name), flags, error);
 
   const FileName* name = get_absolute(dirfd, ar_name);
   if (!name) {
@@ -222,14 +222,14 @@ int Process::handle_unlink(const int dirfd, const char * const ar_name,
 }
 
 int Process::handle_rmdir(const char * const ar_name, const int error) {
-  TRACK(FB_DEBUG_PROC, "this=%s, ar_name=%s, error=%d", D(this), D(ar_name), error);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "ar_name=%s, error=%d", D(ar_name), error);
 
   return handle_unlink(AT_FDCWD, ar_name, AT_REMOVEDIR, error);
 }
 
 int Process::handle_mkdir(const int dirfd, const char * const ar_name, const int error) {
-  TRACK(FB_DEBUG_PROC, "this=%s, dirfd=%d, ar_name=%s, error=%d",
-        D(this), dirfd, D(ar_name), error);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "dirfd=%d, ar_name=%s, error=%d",
+         dirfd, D(ar_name), error);
 
   const FileName* name = get_absolute(dirfd, ar_name);
   if (!name) {
@@ -254,8 +254,8 @@ int Process::handle_mkdir(const int dirfd, const char * const ar_name, const int
 
 int Process::handle_pipe(const int fd1, const int fd2, const int flags,
                          const int error) {
-  TRACK(FB_DEBUG_PROC, "this=%s, fd1=%d, fd2=%d, flags=%d, error=%d",
-        D(this), fd1, fd2, flags, error);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "fd1=%d, fd2=%d, flags=%d, error=%d",
+         fd1, fd2, flags, error);
 
   if (error) {
     return 0;
@@ -284,8 +284,8 @@ int Process::handle_pipe(const int fd1, const int fd2, const int flags,
 
 int Process::handle_dup3(const int oldfd, const int newfd, const int flags,
                          const int error) {
-  TRACK(FB_DEBUG_PROC, "this=%s, oldfd=%d, newfd=%d, flags=%d, error=%d",
-        D(this), oldfd, newfd, flags, error);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "oldfd=%d, newfd=%d, flags=%d, error=%d",
+         oldfd, newfd, flags, error);
 
   switch (error) {
     case EBADF:
@@ -325,9 +325,9 @@ int Process::handle_dup3(const int oldfd, const int newfd, const int flags,
 int Process::handle_rename(const int olddirfd, const char * const old_ar_name,
                            const int newdirfd, const char * const new_ar_name,
                            const int error) {
-  TRACK(FB_DEBUG_PROC,
-        "this=%s, olddirfd=%d, old_ar_name=%s, newdirfd=%d, new_ar_name=%s, error=%d",
-        D(this), olddirfd, D(old_ar_name), newdirfd, D(new_ar_name), error);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this,
+         "olddirfd=%d, old_ar_name=%s, newdirfd=%d, new_ar_name=%s, error=%d",
+         olddirfd, D(old_ar_name), newdirfd, D(new_ar_name), error);
 
   if (error) {
     return 0;
@@ -402,8 +402,9 @@ int Process::handle_rename(const int olddirfd, const char * const old_ar_name,
 int Process::handle_symlink(const char * const old_ar_name,
                             const int newdirfd, const char * const new_ar_name,
                             const int error) {
-  TRACK(FB_DEBUG_PROC, "this=%s, old_ar_name=%s, newdirfd=%d, new_ar_name=%s, error=%d",
-        D(this), D(old_ar_name), newdirfd, D(new_ar_name), error);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this,
+         "old_ar_name=%s, newdirfd=%d, new_ar_name=%s, error=%d",
+         D(old_ar_name), newdirfd, D(new_ar_name), error);
 
   if (!error) {
     disable_shortcutting_bubble_up("Process created a symlink ([" + d(newdirfd) + "]" +
@@ -414,7 +415,7 @@ int Process::handle_symlink(const char * const old_ar_name,
 }
 
 int Process::handle_clear_cloexec(const int fd) {
-  TRACK(FB_DEBUG_PROC, "this=%s, fd=%d", D(this), fd);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "fd=%d", fd);
 
   if (!get_fd(fd)) {
     disable_shortcutting_bubble_up("Process successfully cleared cloexec on fd (" + d(fd) +
@@ -428,8 +429,8 @@ int Process::handle_clear_cloexec(const int fd) {
 
 int Process::handle_fcntl(const int fd, const int cmd, const int arg,
                           const int ret, const int error) {
-  TRACK(FB_DEBUG_PROC, "this=%s, fd=%d, cmd=%d, arg=%d, ret=%d, error=%d",
-        D(this), fd, cmd, arg, ret, error);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "fd=%d, cmd=%d, arg=%d, ret=%d, error=%d",
+         fd, cmd, arg, ret, error);
 
   switch (cmd) {
     case F_DUPFD:
@@ -455,7 +456,8 @@ int Process::handle_fcntl(const int fd, const int cmd, const int arg,
 
 int Process::handle_ioctl(const int fd, const int cmd,
                           const int ret, const int error) {
-  TRACK(FB_DEBUG_PROC, "this=%s, fd=%d, cmd=%d, ret=%d, error=%d", D(this), fd, cmd, ret, error);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "fd=%d, cmd=%d, ret=%d, error=%d",
+         fd, cmd, ret, error);
 
   (void) ret;
 
@@ -489,7 +491,7 @@ int Process::handle_ioctl(const int fd, const int cmd,
 }
 
 void Process::handle_read(const int fd) {
-  TRACK(FB_DEBUG_PROC, "this=%s, fd=%d", D(this), fd);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "fd=%d", fd);
 
   if (!get_fd(fd)) {
     disable_shortcutting_bubble_up("Process successfully read from (" + d(fd) +
@@ -504,7 +506,7 @@ void Process::handle_read(const int fd) {
 }
 
 void Process::handle_write(const int fd) {
-  TRACK(FB_DEBUG_PROC, "this=%s, fd=%d", D(this), fd);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "fd=%d", fd);
 
   if (!get_fd(fd)) {
     disable_shortcutting_bubble_up("Process successfully wrote to (" + d(fd) +
@@ -519,7 +521,7 @@ void Process::handle_write(const int fd) {
 }
 
 void Process::handle_set_wd(const char * const ar_d) {
-  TRACK(FB_DEBUG_PROC, "this=%s, ar_d=%s", D(this), ar_d);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "ar_d=%s", ar_d);
 
   wd_ = get_absolute(AT_FDCWD, ar_d);
   assert(wd_);
@@ -527,7 +529,7 @@ void Process::handle_set_wd(const char * const ar_d) {
 }
 
 void Process::handle_set_fwd(const int fd) {
-  TRACK(FB_DEBUG_PROC, "this=%s, fd=%d", D(this), fd);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "fd=%d", fd);
 
   const FileFD* ffd = get_fd(fd);
   if (!ffd) {
@@ -627,7 +629,8 @@ static inline size_t canonicalize_path(char *path, size_t original_length) {
 }
 
 const FileName* Process::get_absolute(const int dirfd, const char * const name, ssize_t length) {
-  TRACK(FB_DEBUG_PROC, "this=%s, dirfd=%d, name=%s, length=%ld", D(this), dirfd, D(name), length);
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "dirfd=%d, name=%s, length=%ld",
+         dirfd, D(name), length);
 
   if (platform::path_is_absolute(name)) {
     return FileName::Get(name, length);
@@ -730,7 +733,7 @@ std::shared_ptr<std::vector<std::shared_ptr<FileFD>>>
 Process::pop_expected_child_fds(const std::vector<std::string>& argv,
                                 LaunchType *launch_type_p,
                                 const bool failed) {
-  TRACK(FB_DEBUG_PROC, "this=%s, failed=%s", D(this), D(failed));
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "failed=%s", D(failed));
 
   std::shared_ptr<std::vector<std::shared_ptr<firebuild::FileFD>>> fds;
   if (expected_child_) {
@@ -755,7 +758,7 @@ Process::pop_expected_child_fds(const std::vector<std::string>& argv,
 }
 
 bool Process::any_child_not_finalized() {
-  TRACK(FB_DEBUG_PROC, "this=%s", D(this));
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "");
 
   if (exec_pending_ || pending_popen_child_) {
     return true;
@@ -777,7 +780,7 @@ bool Process::any_child_not_finalized() {
  * Finalize the current process.
  */
 void Process::do_finalize() {
-  TRACK(FB_DEBUG_PROC, "this=%s", D(this));
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "");
 
   /* Now we can ack the previous system()'s second message,
    * or a pending pclose() or wait*(). */
@@ -794,7 +797,7 @@ void Process::do_finalize() {
  * bubble it up.
  */
 void Process::maybe_finalize() {
-  TRACK(FB_DEBUG_PROC, "this=%s", D(this));
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "");
 
   if (state() != FB_PROC_TERMINATED) {
     return;
@@ -810,7 +813,7 @@ void Process::maybe_finalize() {
 }
 
 void Process::finish() {
-  TRACK(FB_DEBUG_PROC, "this=%s", D(this));
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "");
 
   if (FB_DEBUGGING(FB_DEBUG_PROC) && expected_child_) {
     FB_DEBUG(FB_DEBUG_PROC, "Expected system()/popen()/posix_spawn() children that did not appear"
@@ -823,8 +826,8 @@ void Process::finish() {
 
 void Process::disable_shortcutting_bubble_up_to_excl(const Process *stop, const std::string& reason,
                                                      const Process *p) {
-  TRACK(FB_DEBUG_PROC, "this=%s, stop=%s, reason=%s, source=%s",
-        D(this), D(stop), D(reason), D(p));
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "stop=%s, reason=%s, source=%s",
+         D(stop), D(reason), D(p));
 
   if (this == stop) {
     return;
@@ -839,7 +842,7 @@ void Process::disable_shortcutting_bubble_up_to_excl(const Process *stop, const 
 }
 
 void Process::disable_shortcutting_bubble_up(const std::string& reason, const Process *p) {
-  TRACK(FB_DEBUG_PROC, "this=%s, reason=%s, source=%s", D(this), D(reason), D(p));
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "reason=%s, source=%s", D(reason), D(p));
 
   disable_shortcutting_bubble_up_to_excl(NULL, reason, p);
 }


### PR DESCRIPTION
Improves #432

See the comment I added to 432.

Nitpicking:

Feel free to suggest a better name than TRACKX. For some reason I don't like the KX letter combo visually :)

Maybe TRACK1, if we keep in mind that one day we might want to add TRACK2 that prints two variables upon destruction.

Independently to this, I'm wondering if TRACE would be a more appropriate word to use. And then TRACEX, or TRACE1, or whateever better idea.