### PR TITLE
supervisor: Fix buffer overrun in the method trackers

### DIFF
--- a/src/firebuild/debug.h
+++ b/src/firebuild/debug.h
@@ -168,17 +168,19 @@ class MethodTracker {
         file_ = last_slash + 1;
       }
       char buf[1024];
-      int offset = snprintf(buf, sizeof(buf), "%*s-> %s()  (%s:%d)%s",
-                            2 * method_tracker_level, "", func_, file_, line_,
-                            print_obj_on_enter || fmt[0] ? "  " : "");
-      if (print_obj_on_enter) {
+      size_t offset = snprintf(buf, sizeof(buf), "%*s-> %s()  (%s:%d)%s",
+                               2 * method_tracker_level, "", func_, file_, line_,
+                               print_obj_on_enter || fmt[0] ? "  " : "");
+      if (print_obj_on_enter && offset < sizeof(buf)) {
         offset += snprintf(buf + offset, sizeof(buf) - offset, "%s=%s%s",
                            obj_name_, ((*resolved_d_)(obj_ptr_, 0)).c_str(), fmt[0] ? ", " : "");
       }
-      va_list ap;
-      va_start(ap, fmt);
-      vsnprintf(buf + offset, sizeof(buf) - offset, fmt, ap);
-      va_end(ap);
+      if (offset < sizeof(buf)) {
+        va_list ap;
+        va_start(ap, fmt);
+        vsnprintf(buf + offset, sizeof(buf) - offset, fmt, ap);
+        va_end(ap);
+      }
       FB_DEBUG(flag_, buf);
       method_tracker_level++;
     }
@@ -187,9 +189,9 @@ class MethodTracker {
     if (FB_DEBUGGING(flag_)) {
       method_tracker_level--;
       char buf[1024];
-      int offset = snprintf(buf, sizeof(buf), "%*s<- %s()  (%s:%d)",
-                            2 * method_tracker_level, "", func_, file_, line_);
-      if (print_obj_on_leave_) {
+      size_t offset = snprintf(buf, sizeof(buf), "%*s<- %s()  (%s:%d)",
+                               2 * method_tracker_level, "", func_, file_, line_);
+      if (print_obj_on_leave_ && offset < sizeof(buf)) {
         snprintf(buf + offset, sizeof(buf) - offset, "  %s=%s",
                  obj_name_, ((*resolved_d_)(obj_ptr_, 0)).c_str());
       }


### PR DESCRIPTION
Explanation:

I thought `snprintf()` returned the number of bytes actually stored. Nope, it returns the number of bytes it would have stored, had there been enough space. So `offset` could grow bigger than `sizeof(buf)`.

The next time I passed `sizeof(buf) - offset` to another `snprintf()`, it became a giant integer since it's a `size_t` (i.e. unsigned) parameter.