### PR TITLE
Preparation for pipe replaying, round 2

### DIFF
--- a/src/firebuild/cache_object_format.fbs
+++ b/src/firebuild/cache_object_format.fbs
@@ -33,6 +33,11 @@ table Dir {
   entry:[string];
 }
 
+table PipeFds {
+  // Client-side fds pointing to the same pipe
+  fd:[int];
+}
+
 // Properties of a process that are known when it starts up, and are
 // expected to be the same across identical launches. These take a key
 // part in deciding whether it can be shortcutted. This includes command
@@ -52,6 +57,8 @@ table ProcessFingerprint {
   env:[string];
   // The initial working directory
   wd:string (required);
+  // For each outbound pipe, this contains the client-side fds
+  outbound_pipe:[PipeFds];
   // special purpose file descriptors, not having file name
   //optional stdin:File;
   //optional stdout:File;

--- a/src/interceptor/intercept.c
+++ b/src/interceptor/intercept.c
@@ -481,24 +481,36 @@ static void reopen_fd_fifo(const char* fd_fifo_str) {
   int reopen_fd, reopen_flags, fifo_name_offset;
   sscanf(fd_fifo_str, "%d:%d %n", &reopen_fd, &reopen_flags, &fifo_name_offset);
   const char* reopen_fd_fifo = fd_fifo_str + fifo_name_offset;
-  /* Open the the fifo in O_RDONLY mode because the supervisor's side may have already been
-   * closed. This can happen when the supervisor-side Pipe's fd0 end is closed and this fifo's
-   * Pipe fd1 end is cleaned up. */
-  int tmp_fd = ic_orig_open(reopen_fd_fifo, O_NONBLOCK | O_RDONLY);
-  int fd = ic_orig_open(reopen_fd_fifo, reopen_flags | O_WRONLY);
-  ic_orig_close(tmp_fd);
-  assert(fd != -1 && "reopening fd failed");
-  if (fd != reopen_fd) {
-    /* dup2, because fds to be reopened can't have O_CLOEXEC */
+  /* reopen_fd_fifo is either a full path for the file to reopen, or an integer
+   * for the fd to dup2(). */
+  if (reopen_fd_fifo[0] == '/') {
+    /* Open the the fifo in O_RDONLY mode because the supervisor's side may have already been
+     * closed. This can happen when the supervisor-side Pipe's fd0 end is closed and this fifo's
+     * Pipe fd1 end is cleaned up. */
+    int tmp_fd = ic_orig_open(reopen_fd_fifo, O_NONBLOCK | O_RDONLY);
+    int fd = ic_orig_open(reopen_fd_fifo, reopen_flags | O_WRONLY);
+    ic_orig_close(tmp_fd);
+    assert(fd != -1 && "reopening fd failed");
+    if (fd != reopen_fd) {
+      /* dup2, because fds to be reopened can't have O_CLOEXEC */
+#ifndef NDEBUG
+      int dup2_ret =
+#endif
+          ic_orig_dup2(fd, reopen_fd);
+      assert(dup2_ret == reopen_fd);
+      ic_orig_close(fd);
+    }
+    /* the fifo is opened on both ends, there is no need for the file */
+    ic_orig_unlink(reopen_fd_fifo);
+  } else {
+    int fd;
+    sscanf(reopen_fd_fifo, "%d", &fd);
 #ifndef NDEBUG
     int dup2_ret =
 #endif
         ic_orig_dup2(fd, reopen_fd);
     assert(dup2_ret == reopen_fd);
-    ic_orig_close(fd);
   }
-  /* the fifo is opened on both ends, there is no need for the file */
-  ic_orig_unlink(reopen_fd_fifo);
 }
 
 /**  Set up the main supervisor connection */


### PR DESCRIPTION
Next step in preparation for pipe replaying. Two architectural changes, not trivial ones, but not extremely complex ones either. 

Successfully passed 3 rounds of complete test suite runs.

The second commit hopefully demonstrates pretty well how it's incompatible with the first iteration of your #449.