### PR TITLE
supervisor: Match exes faster to blacklist and cache skip list

### DIFF
--- a/src/firebuild/config.cc
+++ b/src/firebuild/config.cc
@@ -17,6 +17,7 @@
 
 #include "common/firebuild_common.h"
 #include "firebuild/debug.h"
+#include "firebuild/exe_matcher.h"
 #include "firebuild/file_name.h"
 
 #define GLOBAL_CONFIG "/etc/firebuild.conf"
@@ -25,6 +26,9 @@
 namespace firebuild {
 
 std::vector<const FileName*> *ignore_locations = nullptr;
+
+ExeMatcher* blacklist_matcher = nullptr;
+ExeMatcher* skip_cache_matcher = nullptr;
 
 /** Parse configuration file
  *
@@ -188,6 +192,20 @@ void read_config(libconfig::Config *cfg, const char *custom_cfg_file,
   ignore_locations = new std::vector<const FileName *>();
   for (int i = 0; i < ignores.getLength(); i++) {
     ignore_locations->push_back(FileName::Get(ignores[i].c_str()));
+  }
+
+  libconfig::Setting& blacklist = cfg->getRoot()["processes"]["blacklist"];
+  assert(!blacklist_matcher);
+  blacklist_matcher = new ExeMatcher();
+  for (int i = 0; i < blacklist.getLength(); i++) {
+    blacklist_matcher->add(blacklist[i]);
+  }
+
+  libconfig::Setting& skip_cache = cfg->getRoot()["processes"]["skip_cache"];
+  assert(!skip_cache_matcher);
+  skip_cache_matcher = new ExeMatcher();
+  for (int i = 0; i < skip_cache.getLength(); i++) {
+    skip_cache_matcher->add(skip_cache[i]);
   }
 }
 

--- a/src/firebuild/config.h
+++ b/src/firebuild/config.h
@@ -11,11 +11,15 @@
 #include <libconfig.h++>
 
 #include "common/firebuild_common.h"
+#include "firebuild/exe_matcher.h"
 #include "firebuild/file_name.h"
 
 namespace firebuild {
 
 extern std::vector<const FileName*> *ignore_locations;
+extern ExeMatcher* blacklist_matcher;
+extern ExeMatcher* skip_cache_matcher;
+
 void read_config(libconfig::Config *cfg, const char *custom_cfg_file,
                  const std::list<std::string>& config_strings);
 

--- a/src/firebuild/exe_matcher.h
+++ b/src/firebuild/exe_matcher.h
@@ -1,0 +1,48 @@
+/* Copyright (c) 2021 Interri Kft. */
+/* This file is an unpublished work. All rights reserved. */
+
+#ifndef FIREBUILD_EXE_MATCHER_H_
+#define FIREBUILD_EXE_MATCHER_H_
+
+#include <string>
+#include <unordered_set>
+
+#include "firebuild/file_name.h"
+
+namespace firebuild {
+
+/**
+ * Class for checking if either exe or arg0 matches any of the base names of full names (paths).
+ */
+class ExeMatcher {
+ public:
+  ExeMatcher() : base_names_(), full_names_() {}
+  bool match(const firebuild::FileName* exe_file, const std::string& arg0) const {
+    const std::string exe = exe_file->to_string();
+    size_t pos = exe.rfind('/');
+    const std::string exe_base = exe.substr(pos == std::string::npos ? 0 : pos + 1);
+    pos = arg0.rfind('/');
+    const std::string arg0_base = arg0.substr(pos == std::string::npos ? 0 : pos + 1);
+    if (base_names_.find(exe_base) != base_names_.end()
+        || base_names_.find(arg0_base) != base_names_.end()
+        || full_names_.find(exe) != full_names_.end()
+        || full_names_.find(arg0) != full_names_.end()) {
+      return true;
+    }
+    return false;
+  }
+  void add(const std::string name) {
+    if (name.find('/') == std::string::npos) {
+      full_names_.insert(name);
+    } else {
+      base_names_.insert(name);
+    }
+  }
+
+ private:
+  std::unordered_set<std::string> base_names_;
+  std::unordered_set<std::string> full_names_;
+};
+
+}  // namespace firebuild
+#endif  // FIREBUILD_EXE_MATCHER_H_


### PR DESCRIPTION
Saves ~2.1% of firebuild's CPU time while compiling bash.