### PR TITLE
supervisor: Speed up env_fingerprintable()

### DIFF
--- a/src/firebuild/execed_process_cacher.cc
+++ b/src/firebuild/execed_process_cacher.cc
@@ -32,24 +32,22 @@ ExecedProcessCacher::ExecedProcessCacher(bool no_store,
                                          bool no_fetch,
                                          const libconfig::Setting& envs_skip) :
     no_store_(no_store), no_fetch_(no_fetch),
-    envs_skip_(envs_skip), fingerprints_(), fingerprint_msgs_() { }
+    envs_skip_(), fingerprints_(), fingerprint_msgs_() {
+  for (int i = 0; i < envs_skip.getLength(); i++) {
+    envs_skip_.insert(envs_skip[i]);
+  }
+}
 
 /**
  * Helper for fingerprint() to decide which env vars matter
  */
 bool ExecedProcessCacher::env_fingerprintable(const std::string& name_and_value) const {
   /* Strip off the "=value" part. */
-  std::string name = name_and_value.substr(0, name_and_value.find('='));
+  const std::string name = name_and_value.substr(0, name_and_value.find('='));
 
   /* Env vars to skip, taken from the config files.
    * Note: FB_SOCKET is already filtered out in the interceptor. */
-  for (int i = 0; i < envs_skip_.getLength(); i++) {
-    std::string item = envs_skip_[i];
-    if (name == item) {
-      return false;
-    }
-  }
-  return true;
+  return envs_skip_.find(name) == envs_skip_.end();
 }
 
 /**

--- a/src/firebuild/execed_process_cacher.h
+++ b/src/firebuild/execed_process_cacher.h
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include <libconfig.h++>
 
@@ -45,7 +46,7 @@ class ExecedProcessCacher {
 
   bool no_store_;
   bool no_fetch_;
-  const libconfig::Setting& envs_skip_;
+  std::unordered_set<std::string> envs_skip_;
 
   /* The hashed fingerprint of the processes handled by this cacher. */
   std::unordered_map<const ExecedProcess*, Hash> fingerprints_;


### PR DESCRIPTION
Saves ~0.5% of firebuild's CPU time while compiling bash.