### PR TITLE
supervisor: Debug the destruction of Process and Pipe objects

### DIFF
--- a/src/firebuild/execed_process.h
+++ b/src/firebuild/execed_process.h
@@ -49,7 +49,6 @@ class ExecedProcess : public Process {
   virtual bool exec_started() const {return true;}
   ExecedProcess* exec_point() {return this;}
   const ExecedProcess* exec_point() const {return this;}
-  virtual int exec_count() const {return exec_count_;}
   int64_t sum_utime_u() const {return sum_utime_u_;}
   void set_sum_utime_u(int64_t t) {sum_utime_u_ = t;}
   int64_t sum_stime_u() const {return sum_stime_u_;}
@@ -206,8 +205,6 @@ class ExecedProcess : public Process {
   /// NULL if we prefer not to (although probably could)
   /// cache / shortcut this process.
   ExecedProcessCacher *cacher_;
-  /// Number of execve() hops since the closest ForkedProcess ancestor, for debugging
-  int exec_count_;
   DISALLOW_COPY_AND_ASSIGN(ExecedProcess);
 };
 

--- a/src/firebuild/forked_process.cc
+++ b/src/firebuild/forked_process.cc
@@ -14,7 +14,7 @@ namespace firebuild {
 ForkedProcess::ForkedProcess(const int pid, const int ppid,
                              Process* parent,
                              std::shared_ptr<std::vector<std::shared_ptr<FileFD>>> fds)
-    : Process(pid, ppid, parent ? parent->wd() : FileName::Get(""), parent, fds) {
+    : Process(pid, ppid, 0, parent ? parent->wd() : FileName::Get(""), parent, fds) {
   TRACKX(FB_DEBUG_PROC, 0, 1, Process, this, "pid=%d, ppid=%d, parent=%s", pid, ppid, D(parent));
 
   // add as fork child of parent
@@ -24,6 +24,10 @@ ForkedProcess::ForkedProcess(const int pid, const int ppid,
   } else {
     fb_error("impossible: Process without known fork parent\n");
   }
+}
+
+ForkedProcess::~ForkedProcess() {
+  TRACKX(FB_DEBUG_PROC, 1, 0, Process, this, "");
 }
 
 /* Member debugging method. Not to be called directly, call the global d(obj_or_ptr) instead.

--- a/src/firebuild/forked_process.h
+++ b/src/firebuild/forked_process.h
@@ -22,9 +22,9 @@ class ForkedProcess : public Process {
  public:
   explicit ForkedProcess(const int pid, const int ppid, Process* parent,
                          std::shared_ptr<std::vector<std::shared_ptr<FileFD>>> fds);
+  virtual ~ForkedProcess();
   ExecedProcess* exec_point() {return exec_point_;}
   const ExecedProcess* exec_point() const {return exec_point_;}
-  virtual int exec_count() const {return 0;}
   /**
    * Fail to change to a working directory
    */

--- a/src/firebuild/pipe.cc
+++ b/src/firebuild/pipe.cc
@@ -67,6 +67,10 @@ Pipe::Pipe(int fd0_conn, Process* creator)
   TRACKX(FB_DEBUG_PIPE, 0, 1, Pipe, this, "fd0_conn=%s, creator=%s", D_FD(fd0_conn), D(creator));
 }
 
+Pipe::~Pipe() {
+  TRACKX(FB_DEBUG_PIPE, 1, 0, Pipe, this, "");
+}
+
 std::shared_ptr<Pipe> Pipe::fd0_shared_ptr() {
   assert(!fd0_shared_ptr_generated_);
   fd0_ptrs_held_self_ptr_ = shared_self_ptr_;

--- a/src/firebuild/pipe.h
+++ b/src/firebuild/pipe.h
@@ -126,6 +126,7 @@ typedef enum {
 class Pipe {
  public:
   Pipe(int fd0_conn, Process* creator);
+  ~Pipe();
   /**
    * Shared_ptr of this Pipe for fd0-side references.
    */

--- a/src/firebuild/process.cc
+++ b/src/firebuild/process.cc
@@ -22,10 +22,10 @@ namespace firebuild {
 
 static int fb_pid_counter;
 
-Process::Process(const int pid, const int ppid, const FileName *wd,
+Process::Process(const int pid, const int ppid, const int exec_count, const FileName *wd,
                  Process * parent, std::shared_ptr<std::vector<std::shared_ptr<FileFD>>> fds)
     : parent_(parent), state_(FB_PROC_RUNNING), fb_pid_(fb_pid_counter++),
-      pid_(pid), ppid_(ppid), exit_status_(-1), wd_(wd), fds_(fds),
+      pid_(pid), ppid_(ppid), exec_count_(exec_count), exit_status_(-1), wd_(wd), fds_(fds),
       closed_fds_({}), utime_u_(0), stime_u_(0), aggr_time_(0), fork_children_(),
       expected_child_(), exec_child_(NULL) {
   TRACKX(FB_DEBUG_PROC, 0, 1, Process, this, "pid=%d, ppid=%d, parent=%s", pid, ppid, D(parent));
@@ -957,6 +957,8 @@ std::string Process::d_internal(const int level) const {
 }
 
 Process::~Process() {
+  TRACKX(FB_DEBUG_PROC, 1, 0, Process, this, "");
+
   free(pending_popen_fifo_);
 }
 

--- a/src/firebuild/process.h
+++ b/src/firebuild/process.h
@@ -71,7 +71,7 @@ typedef enum {
  */
 class Process {
  public:
-  Process(int pid, int ppid, const FileName *wd,
+  Process(int pid, int ppid, int exec_count, const FileName *wd,
           Process* parent, std::shared_ptr<std::vector<std::shared_ptr<FileFD>>> fds);
   virtual ~Process();
   bool operator == (Process const & p) const;
@@ -92,6 +92,7 @@ class Process {
   int fb_pid() {return fb_pid_;}
   int pid() const {return pid_;}
   int ppid() const {return ppid_;}
+  int exec_count() const {return exec_count_;}
   int exit_status() const {return exit_status_;}
   void set_exit_status(const int e) {exit_status_ = e;}
   const FileName* wd() {return wd_;}
@@ -396,10 +397,6 @@ class Process {
     on_finalized_ack_fd_ = fd;
   }
 
-  /* For debugging: The "age" of a given PID, i.e. how many execve() hops happened to it.
-   * 0 for a ForkedProcess, 1 for its first ExecedProcess child, 2 for the execed child of
-   * that one, etc. -1 temporarily while constructing a Process object. */
-  virtual int exec_count() const {return -1;}
   /* For debugging. */
   std::string pid_and_exec_count() const {return d(pid()) + "." + d(exec_count());}
   /* For debugging. */
@@ -427,6 +424,10 @@ class Process {
   int fb_pid_;       ///< internal FireBuild id for the process
   int pid_;          ///< UNIX pid
   int ppid_;         ///< UNIX ppid
+  /** For debugging: The "age" of a given PID, i.e. how many execve() hops happened to it.
+   *  0 for a ForkedProcess, 1 for its first ExecedProcess child, 2 for the execed child of
+   *  that one, etc. -1 temporarily while constructing a Process object. */
+  int exec_count_;
   int exit_status_;  ///< exit status 0..255, or -1 if no exit() performed yet
   const FileName* wd_;  ///< Current working directory
   std::shared_ptr<std::vector<std::shared_ptr<FileFD>>> fds_;  ///< Active file descriptors

--- a/src/firebuild/process_tree.cc
+++ b/src/firebuild/process_tree.cc
@@ -72,6 +72,8 @@ ProcessTree::ProcessTree()
 }
 
 ProcessTree::~ProcessTree() {
+  TRACK(FB_DEBUG_PROCTREE, "");
+
   // clean up all processes
   for (auto& pair : fb_pid2proc_) {
     delete(pair.second);


### PR DESCRIPTION
Note:

So far "exec_count" was solved using a virtual method, returning constant 0 for ForkedProcess, or a member variable of ExecedProcess.

While destructing an ExecedProcess, first the Execed boilerplate is destructed, and then this is no longer an ExecedProcess but just a Process. Then the ~Process destructor printed incorrect exec_count in the debug info, due to how the virtual function no longer resolved to the ExecedProcess variable (which is no longer valid).

This is why I changed it to simply a variable of the base class Process, holding whichever value we want it to hold, no matter if it's an Execed or a Forked Process.