### PR TITLE
supervisor: Copy PipeRecorders less often

### DIFF
--- a/src/firebuild/execed_process_cacher.cc
+++ b/src/firebuild/execed_process_cacher.cc
@@ -607,9 +607,9 @@ bool ExecedProcessCacher::apply_shortcut(ExecedProcess *proc,
 
     if (proc->parent()) {
       /* Bubble up the replayed pipe data. */
-      std::vector<std::shared_ptr<PipeRecorder>> recorders =
+      std::vector<std::shared_ptr<PipeRecorder>>& recorders =
           pipe->proc2recorders[proc->parent_exec_point()];
-      PipeRecorder::record_data_from_regular_fd(recorders, fd, st.st_size);
+      PipeRecorder::record_data_from_regular_fd(&recorders, fd, st.st_size);
     }
     close(fd);
   }

--- a/src/firebuild/firebuild.cc
+++ b/src/firebuild/firebuild.cc
@@ -257,15 +257,13 @@ void accept_exec_child(ExecedProcess* proc, int fd_conn,
         int fifo_fd = make_fifo_fd_conn(proc, inherited_pipe.fds[0], &fifo_fds);
         /* Find the recorders belonging to the parent process. We need to record to all those,
          * plus create a new recorder for ourselves (unless shortcutting is already disabled). */
-        auto recorders = std::vector<std::shared_ptr<firebuild::PipeRecorder>>();
-        if (proc->parent()) {
-          recorders = pipe->proc2recorders[proc->parent_exec_point()];
-        }
+        auto  recorders =  proc->parent() ? pipe->proc2recorders[proc->parent_exec_point()]
+            : std::vector<std::shared_ptr<firebuild::PipeRecorder>>();
         if (proc->can_shortcut()) {
           inherited_pipe.recorder = std::make_shared<PipeRecorder>(proc);
           recorders.push_back(inherited_pipe.recorder);
         }
-        pipe->add_fd1_and_proc(fifo_fd, file_fd.get(), proc, recorders);
+        pipe->add_fd1_and_proc(fifo_fd, file_fd.get(), proc, std::move(recorders));
         FB_DEBUG(FB_DEBUG_PIPE, "reopening process' fd: "+ d(inherited_pipe.fds[0])
                  + " as new fd1: " + d(fifo_fd) + " of " + d(pipe));
 

--- a/src/firebuild/pipe.cc
+++ b/src/firebuild/pipe.cc
@@ -371,7 +371,7 @@ pipe_op_result Pipe::forward(int fd1, bool drain, bool in_callback) {
             FB_DEBUG(FB_DEBUG_PIPE, "sent " + d(received) + " bytes from fd: "
                      + d_fd(fd1) + "to fd: " + d_fd(fd0_conn) + " using tee");
             /* Save the data, consuming it from the pipe. */
-            PipeRecorder::record_data_from_unix_pipe(fd1_end->recorders, fd1, received);
+            PipeRecorder::record_data_from_unix_pipe(&fd1_end->recorders, fd1, received);
           }
         } else {
           /* We do not want to record the data. Forward it using splice() which consumes it from the
@@ -448,7 +448,7 @@ pipe_op_result Pipe::forward(int fd1, bool drain, bool in_callback) {
       assert(bufsize >= received);
       const char * buf_to_save = buf_.data() + bufsize - received;
       /* Record it. */
-      PipeRecorder::record_data_from_buffer(fd1_end->recorders, buf_to_save, received);
+      PipeRecorder::record_data_from_buffer(&fd1_end->recorders, buf_to_save, received);
       /* Try to send it, too. */
       send_ret = send_buf();
     }

--- a/src/firebuild/pipe_recorder.h
+++ b/src/firebuild/pipe_recorder.h
@@ -159,13 +159,13 @@ class PipeRecorder {
   /** Close the backing fd, drop the data that was written so far. Set to abandoned state. */
   void abandon();
 
-  static bool has_active_recorder(const std::vector<std::shared_ptr<PipeRecorder>> recorders);
+  static bool has_active_recorder(const std::vector<std::shared_ptr<PipeRecorder>>& recorders);
 
-  static void record_data_from_buffer(std::vector<std::shared_ptr<PipeRecorder>> recorders,
+  static void record_data_from_buffer(std::vector<std::shared_ptr<PipeRecorder>> *recorders,
                                       const char *buf, ssize_t len);
-  static void record_data_from_unix_pipe(std::vector<std::shared_ptr<PipeRecorder>> recorders,
+  static void record_data_from_unix_pipe(std::vector<std::shared_ptr<PipeRecorder>> *recorders,
                                          int fd, ssize_t len);
-  static void record_data_from_regular_fd(std::vector<std::shared_ptr<PipeRecorder>> recorders,
+  static void record_data_from_regular_fd(std::vector<std::shared_ptr<PipeRecorder>> *recorders,
                                           int fd, ssize_t len);
 
   static void set_base_dir(const char *dir);


### PR DESCRIPTION
Minimally improves performance ~0.1%, but I think this is also nicer.