### PR TITLE
supervisor: Register reason for not shortcutting the process as a con…

### DIFF
--- a/src/firebuild/execed_process.cc
+++ b/src/firebuild/execed_process.cc
@@ -377,7 +377,7 @@ bool ExecedProcess::shortcut() {
 
 void ExecedProcess::disable_shortcutting_bubble_up_to_excl(
     ExecedProcess *stop,
-    const std::string& reason,
+    const char* reason,
     const ExecedProcess *p,
     ExecedProcess *shortcutable_ancestor,
     bool shortcutable_ancestor_is_set) {
@@ -411,20 +411,52 @@ void ExecedProcess::disable_shortcutting_bubble_up_to_excl(
   }
 }
 
-void ExecedProcess::disable_shortcutting_bubble_up(const std::string& reason,
+void ExecedProcess::disable_shortcutting_bubble_up_to_excl(
+    ExecedProcess *stop,
+    const char* reason,
+    const int fd,
+    const ExecedProcess *p,
+    ExecedProcess *shortcutable_ancestor,
+    bool shortcutable_ancestor_is_set) {
+  disable_shortcutting_bubble_up_to_excl(stop, reason, p, shortcutable_ancestor,
+                                         shortcutable_ancestor_is_set);
+  FB_DEBUG(FB_DEBUG_PROC, "fd: " + d(fd));
+}
+void ExecedProcess::disable_shortcutting_bubble_up(const char* reason,
                                                    const ExecedProcess *p) {
   TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "reason=%s, source=%s", D(reason), D(p));
 
   disable_shortcutting_bubble_up_to_excl(NULL, reason, p);
 }
 
-void ExecedProcess::disable_shortcutting_only_this(const std::string &reason,
+void ExecedProcess::disable_shortcutting_bubble_up(const char* reason,
+                                                   const int fd,
+                                                   const ExecedProcess *p) {
+  disable_shortcutting_bubble_up(reason, p);
+  FB_DEBUG(FB_DEBUG_PROC, "fd: " + d(fd));
+}
+
+void ExecedProcess::disable_shortcutting_bubble_up(const char* reason,
+                                                   const FileName& file,
+                                                   const ExecedProcess *p) {
+  disable_shortcutting_bubble_up(reason, p);
+  FB_DEBUG(FB_DEBUG_PROC, "file: " + d(file));
+}
+
+void ExecedProcess::disable_shortcutting_bubble_up(const char* reason,
+                                                   const std::string& str,
+                                                   const ExecedProcess *p) {
+  disable_shortcutting_bubble_up(reason, p);
+  FB_DEBUG(FB_DEBUG_PROC, d(str));
+}
+
+void ExecedProcess::disable_shortcutting_only_this(const char* reason,
                                                    const ExecedProcess *p) {
   TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "reason=%s, source=%s", D(reason), D(p));
 
   if (can_shortcut_) {
     can_shortcut_ = false;
-    assert_cmp(cant_shortcut_reason_, ==, "");
+    assert(cant_shortcut_reason_ == nullptr);
     cant_shortcut_reason_ = reason;
     assert_null(cant_shortcut_proc_);
     cant_shortcut_proc_ = p ? p : this;

--- a/src/firebuild/execed_process.h
+++ b/src/firebuild/execed_process.h
@@ -123,7 +123,7 @@ class ExecedProcess : public Process {
    * @param p process the event preventing shortcutting happened in, or
    *     omitted for the current process
    */
-  virtual void disable_shortcutting_only_this(const std::string &reason,
+  virtual void disable_shortcutting_only_this(const char* reason,
                                               const ExecedProcess *p = NULL);
   /**
    * Process and parents (transitively) up to (excluding) "stop" can't be short-cut because
@@ -137,7 +137,11 @@ class ExecedProcess : public Process {
    *        (when shortcutable_ancestor_is_set is true)
    * @param shortcutable_ancestor_is_set the shortcutable_ancestor is computed
    */
-  void disable_shortcutting_bubble_up_to_excl(ExecedProcess *stop, const std::string& reason,
+  void disable_shortcutting_bubble_up_to_excl(ExecedProcess *stop, const char* reason,
+                                              const ExecedProcess *p = NULL,
+                                              ExecedProcess *shortcutable_ancestor = nullptr,
+                                              bool shortcutable_ancestor_is_set = false);
+  void disable_shortcutting_bubble_up_to_excl(ExecedProcess *stop, const char* reason, int fd,
                                               const ExecedProcess *p = NULL,
                                               ExecedProcess *shortcutable_ancestor = nullptr,
                                               bool shortcutable_ancestor_is_set = false);
@@ -148,7 +152,13 @@ class ExecedProcess : public Process {
    * @param p process the event preventing shortcutting happened in, or
    *     omitted for the current process
    */
-  void disable_shortcutting_bubble_up(const std::string& reason, const ExecedProcess *p = NULL);
+  void disable_shortcutting_bubble_up(const char* reason, const ExecedProcess *p = NULL);
+  void disable_shortcutting_bubble_up(const char* reason, const int fd,
+                                      const ExecedProcess *p = NULL);
+  void disable_shortcutting_bubble_up(const char* reason, const FileName& file,
+                                      const ExecedProcess *p = NULL);
+  void disable_shortcutting_bubble_up(const char* reason, const std::string& str,
+                                      const ExecedProcess *p = NULL);
 
   bool was_shortcut() const {return was_shortcut_;}
   void set_was_shortcut(bool value) {was_shortcut_ = value;}
@@ -213,7 +223,7 @@ class ExecedProcess : public Process {
   std::vector<inherited_pipe_t> inherited_pipes_ = {};
   void store_in_cache();
   /// Reason for this process can't be short-cut
-  std::string cant_shortcut_reason_ = "";
+  const char* cant_shortcut_reason_ = nullptr;
   /// Process the event preventing short-cutting happened in
   const Process *cant_shortcut_proc_ = NULL;
   /// Helper object for storing in / retrieving from cache.

--- a/src/firebuild/process_proto_adaptor.cc
+++ b/src/firebuild/process_proto_adaptor.cc
@@ -24,7 +24,7 @@ int ProcessPBAdaptor::msg(Process *p, const FBB_dlopen *dlo, int fd_conn, const 
   } else {
     std::string filename = fbb_dlopen_has_absolute_filename(dlo) ?
                            fbb_dlopen_get_absolute_filename(dlo) : "NULL";
-    p->exec_point()->disable_shortcutting_bubble_up("Process failed to dlopen() " + filename);
+    p->exec_point()->disable_shortcutting_bubble_up("Process failed to dlopen() ", filename);
     return 0;
   }
 }


### PR DESCRIPTION
…st char*

Print parameters only in debugging. This saves allocation, formatting and
deletion of strings.