### PR TITLE
supervisor: Calculate process fingerprint without serializing it

### DIFF
--- a/src/firebuild/hash.h
+++ b/src/firebuild/hash.h
@@ -35,6 +35,13 @@ class Hash {
   Hash()
       : arr_()
   {}
+  explicit Hash(const uint8_t* arr)
+      : arr_() {
+    memcpy(arr_, arr, sizeof(arr_));
+    if (arr_[hash_size_ - 1] & 0x3) {
+      arr_[hash_size_ - 1] &= ~0x3;
+    }
+  }
 
   bool operator==(const Hash& src) const {
     return memcmp(&arr_, &src.arr_, hash_size_) == 0;


### PR DESCRIPTION
This saves ~4% of CPU time in first runs (compiling bash).