### PR TITLE
supervisor: Use the raw (architecture dependent) hash everywhere

### DIFF
--- a/src/firebuild/fbbfp.def
+++ b/src/firebuild/fbbfp.def
@@ -7,15 +7,18 @@
 # This is a Python dictionary, to be read and processed by "generate_fbb".
 
 {
-  "types_with_custom_debugger": ["XXH128_canonical_t"],
+  "types_with_custom_debugger": ["XXH128_hash_t"],
 
   "extra_c": """
-    static void fbbfp_debug_XXH128_canonical_t(FILE *f, XXH128_canonical_t value) {
+    static void fbbfp_debug_XXH128_hash_t(FILE *f, XXH128_hash_t value) {
       fputs("[ ", f);
       const char *sep = "";
-      for (int i = 0; i < 16; i++) {
-        fprintf(f, "%s%d", sep, value.digest[i]);
+      for (int i = 0; i < 8; i++) {
+        fprintf(f, "%s%lu", sep, (value.high64 >> ((7 - i) * 8)) & 0xff);
         sep = ", ";
+      }
+      for (int i = 0; i < 8; i++) {
+        fprintf(f, "%s%lu", sep, (value.low64 >> ((7 - i) * 8)) & 0xff);
       }
       fputs(" ]", f);
     }
@@ -29,21 +32,21 @@
   "tags": [
     ("file", [
       # file path, absolute or relative
-      (REQUIRED, STRING,               "path"),
+      (REQUIRED, STRING,          "path"),
       # checksum (binary) of the file content, empty if file is not found
-      (REQUIRED, "XXH128_canonical_t", "hash"),
+      (REQUIRED, "XXH128_hash_t", "hash"),
       # TODO add alternate hash values generated after preprocessing the file
       # with programs keeping the semantic content (e.g. removing white spaces)
-      #(REQUIRED, "XXH128_canonical_t", "alt_hash"),
+      #(REQUIRED, "XXH128_hash_t", "alt_hash"),
 
       # last modification time - FIXME in what unit?
-      #(OPTIONAL, "long",               "mtime"),
+      #(OPTIONAL, "long",          "mtime"),
       # file size, length in case of stdio
-      #(OPTIONAL, "size_t",             "size"),
+      #(OPTIONAL, "size_t",        "size"),
       # TODO refine mode
-      (OPTIONAL, "mode_t",             "mode"),
+      (OPTIONAL, "mode_t",        "mode"),
       # The reason why the file could not be opened.
-      #(OPTIONAL, "int",                "error_no"),
+      #(OPTIONAL, "int",           "error_no"),
     ]),
 
     ("pipe_fds", [

--- a/src/firebuild/fbbstore.def
+++ b/src/firebuild/fbbstore.def
@@ -7,15 +7,18 @@
 # This is a Python dictionary, to be read and processed by "generate_fbb".
 
 {
-  "types_with_custom_debugger": ["XXH128_canonical_t"],
+  "types_with_custom_debugger": ["XXH128_hash_t"],
 
   "extra_c": """
-    static void fbbstore_debug_XXH128_canonical_t(FILE *f, XXH128_canonical_t value) {
+    static void fbbstore_debug_XXH128_hash_t(FILE *f, XXH128_hash_t value) {
       fputs("[ ", f);
       const char *sep = "";
-      for (int i = 0; i < 16; i++) {
-        fprintf(f, "%s%d", sep, value.digest[i]);
+      for (int i = 0; i < 8; i++) {
+        fprintf(f, "%s%lu", sep, (value.high64 >> ((7 - i) * 8)) & 0xff);
         sep = ", ";
+      }
+      for (int i = 0; i < 8; i++) {
+        fprintf(f, "%s%lu", sep, (value.low64 >> ((7 - i) * 8)) & 0xff);
       }
       fputs(" ]", f);
     }
@@ -29,21 +32,21 @@
   "tags": [
     ("file", [
       # file path, absolute or relative
-      (REQUIRED, STRING,               "path"),
+      (REQUIRED, STRING,          "path"),
       # checksum (binary) of the file content, empty if file is not found
-      (REQUIRED, "XXH128_canonical_t", "hash"),
+      (REQUIRED, "XXH128_hash_t", "hash"),
       # TODO add alternate hash values generated after preprocessing the file
       # with programs keeping the semantic content (e.g. removing white spaces)
-      #(REQUIRED, "XXH128_canonical_t", "alt_hash"),
+      #(REQUIRED, "XXH128_hash_t", "alt_hash"),
 
       # last modification time - FIXME in what unit?
-      #(OPTIONAL, "long",               "mtime"),
+      #(OPTIONAL, "long",          "mtime"),
       # file size, length in case of stdio
-      #(OPTIONAL, "size_t",             "size"),
+      #(OPTIONAL, "size_t",        "size"),
       # TODO refine mode
-      (OPTIONAL, "mode_t",             "mode"),
+      (OPTIONAL, "mode_t",        "mode"),
       # The reason why the file could not be opened.
-      #(OPTIONAL, "int",                "error_no"),
+      #(OPTIONAL, "int",           "error_no"),
     ]),
 
     ("dir", [
@@ -54,9 +57,9 @@
     ("pipe_data", [
       # fd at the time the process started, the lowest one if dup()'ed to
       # multiple fds
-      (REQUIRED, "int",                "fd"),
+      (REQUIRED, "int",           "fd"),
       # Checksum (binary) of the written data
-      (REQUIRED, "XXH128_canonical_t", "hash"),
+      (REQUIRED, "XXH128_hash_t", "hash"),
     ]),
 
     # Things that are read from the external world by the process while
@@ -116,13 +119,13 @@
   # Legacy - can we remove it?
   #  ("process", [
   #    # process id
-  #    (REQUIRED, "pid_t",              "pid"),
+  #    (REQUIRED, "pid_t",         "pid"),
   #    # Checksum (binary) of process and children
-  #    (REQUIRED, "XXH128_canonical_t", "hash"),
-  #    (REQUIRED, FBB,                  "inputs_outputs"),  # tag "process_inputs_outputs"
+  #    (REQUIRED, "XXH128_hash_t", "hash"),
+  #    (REQUIRED, FBB,             "inputs_outputs"),  # tag "process_inputs_outputs"
   #    # exit status of the process
-  #    (REQUIRED, "int",                "exit_status"),
-  #    (REQUIRED, "XXH128_canonical_t", "child_hash"),
+  #    (REQUIRED, "int",           "exit_status"),
+  #    (REQUIRED, "XXH128_hash_t", "child_hash"),
   #    # TODO
   #    # signals?
   #  ]),

--- a/src/firebuild/file_usage.h
+++ b/src/firebuild/file_usage.h
@@ -205,7 +205,7 @@ bool operator==(const FileUsage& lhs, const FileUsage& rhs);
 
 struct FileUsageHasher {
   std::size_t operator()(const FileUsage& f) const noexcept {
-    XXH64_hash_t hash = XXH3_64bits_withSeed(f.initial_hash_.to_binary(), Hash::hash_size(),
+    XXH64_hash_t hash = XXH3_64bits_withSeed(f.initial_hash_.get_ptr(), Hash::hash_size(),
                                              f.unknown_err_);
     unsigned char merged_state = f.initial_state_;
     merged_state |= f.stated_ << 5;

--- a/src/firebuild/hashed_fbb_file_vector.h
+++ b/src/firebuild/hashed_fbb_file_vector.h
@@ -23,10 +23,10 @@ class HashedFbbFileVector {
     FBBSTORE_Builder_file& new_file = files_.emplace_back();
     fbbstore_builder_file_init(&new_file);
     fbbstore_builder_file_set_path_with_length(&new_file, file_name->c_str(), file_name->length());
-    fbbstore_builder_file_set_hash(&new_file, content_hash.to_canonical());
+    fbbstore_builder_file_set_hash(&new_file, content_hash.get());
     if (mode != -1) fbbstore_builder_file_set_mode(&new_file, mode);
     hashes_.push_back({file_name->hash_XXH128(),
-                       *reinterpret_cast<const XXH128_hash_t*>(content_hash.to_binary()),
+                       content_hash.get(),
                        {0, static_cast<XXH64_hash_t>(mode)}});
   }
   void add(const FileName* file_name, const FileUsage* fu) {

--- a/src/firebuild/obj_cache.cc
+++ b/src/firebuild/obj_cache.cc
@@ -286,7 +286,7 @@ std::vector<Hash> ObjCache::list_subkeys(const Hash &key) {
   Hash subkey;
   struct dirent *dirent;
   while ((dirent = readdir(dir)) != NULL) {
-    if (subkey.set_hash_from_ascii(dirent->d_name)) {
+    if (subkey.set_from_ascii(dirent->d_name)) {
       ret.push_back(subkey);
     }
   }


### PR DESCRIPTION
Only use the canonicalized (architecture independent) format for
converting to base64 representation.

Fixes #545