### PR TITLE
interceptor: Don't set file states in the fork child

### DIFF
--- a/src/interceptor/intercept.c
+++ b/src/interceptor/intercept.c
@@ -382,7 +382,6 @@ static void atfork_child_handler(void) {
 
     /* Reinitialize other stuff */
     reset_interceptors();
-    set_all_notify_on_read_write_states();
     ic_pid = ic_orig_getpid();
 
     /* Reconnect to supervisor */


### PR DESCRIPTION
This sort of reverts commit f65b216bfdba19964b724b4a2d44304222926bb6.

Fixes #564