### PR TITLE
firebuild: Remove slot for supporting fcloseall()

### DIFF
--- a/src/common/fbbcomm.def
+++ b/src/common/fbbcomm.def
@@ -231,11 +231,6 @@
       (OPTIONAL, "int", "error_no"),
     ]),
 
-    ("fcloseall", [
-      # error no., when ret = -1
-      (OPTIONAL, "int", "error_no"),
-    ]),
-
     ("chmod", [
       # dir file descriptor for fchmodat()
       (OPTIONAL, "int", "dirfd"),

--- a/src/firebuild/firebuild.cc
+++ b/src/firebuild/firebuild.cc
@@ -938,7 +938,6 @@ void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf,
     case FBBCOMM_TAG_fb_error:
     case FBBCOMM_TAG_fchmod:
     case FBBCOMM_TAG_fchown:
-    case FBBCOMM_TAG_fcloseall:
     case FBBCOMM_TAG_fpathconf:
     case FBBCOMM_TAG_freopen:
     case FBBCOMM_TAG_fstat:

--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -315,7 +315,9 @@ generate("int", "fclose", "FILE *stream",
          msg_skip_fields=["stream"],
          msg_add_fields=["fbbcomm_builder_close_set_fd(&ic_msg, fd);"])
 
-skip("fcloseall")  # Only closes the high level streams, not the underlying fds.
+# Unlike fclose(), fcloseall() only closes the high level streams and not the underlying fds.
+# So we don't care about it at all.
+skip("fcloseall")
 
 # Intercept opendir, closedir (no need to intercept fdopendir)
 generate("DIR *", "opendir", "const char *file",


### PR DESCRIPTION
fcloseall() closes the high-level streams only, there's nothing for us to do.