### PR TITLE
firebuild: Return uint32_t from FileName:length()

### DIFF
--- a/src/firebuild/file_name.h
+++ b/src/firebuild/file_name.h
@@ -28,7 +28,7 @@ class FileName {
   }
   const char * c_str() const {return name_;}
   std::string to_string() const {return std::string(name_);}
-  size_t length() const {return length_;}
+  uint32_t length() const {return length_;}
   size_t hash() const {return XXH3_64bits(name_, length_);}
   const XXH128_hash_t& hash_XXH128() const {
     auto it = hash_db_->find(this);


### PR DESCRIPTION
The length is stored as uint32_t already. Inflating the range for on
getting it is pointless and causes a warning when trying to store the
returned value as uint32_t again.