### PR TITLE
firebuild: Store process running times in a file, if requested

### DIFF
--- a/src/firebuild/debug.cc
+++ b/src/firebuild/debug.cc
@@ -91,6 +91,7 @@ static struct flag available_flags[] = {
   { "pipe",              FB_DEBUG_PIPE },
   { "function",          FB_DEBUG_FUNC },
   { "func",              FB_DEBUG_FUNC },
+  { "time",              FB_DEBUG_TIME },
   { NULL, 0 }
 };
 

--- a/src/firebuild/debug.h
+++ b/src/firebuild/debug.h
@@ -43,6 +43,8 @@ enum {
   FB_DEBUG_PIPE         = 1 << 9,
   /* Entering and leaving functions */
   FB_DEBUG_FUNC         = 1 << 10,
+  /* Similar to bash's "time" */
+  FB_DEBUG_TIME         = 1 << 11,
 };
 
 

--- a/src/firebuild/utils.h
+++ b/src/firebuild/utils.h
@@ -10,6 +10,16 @@
 ssize_t fb_copy_file_range(int fd_in, loff_t *off_in, int fd_out, loff_t *off_out, size_t len,
                            unsigned int flags);
 
+/** Subtract two struct timespecs. Equivalent to the same method of BSD. */
+#define timespecsub(a, b, res) do {             \
+  (res)->tv_sec = (a)->tv_sec - (b)->tv_sec;    \
+  (res)->tv_nsec = (a)->tv_nsec - (b)->tv_nsec; \
+  if ((res)->tv_nsec < 0) {                     \
+    (res)->tv_sec--;                            \
+    (res)->tv_nsec += 1000 * 1000 * 1000;       \
+  }                                             \
+} while (0)
+
 namespace firebuild {
 
 void ack_msg(const int conn, const uint32_t ack_num);


### PR DESCRIPTION
This is similar to bash's "time", but shows separately the time needed by
firebuild vs. the time needed by its children.

*** QUESTION: ***

In a preliminary review in email you said you'd rather see it under `-d` (debug). I modified the change accordingly.

I'm not entirely happy with this change. Perf measuring is not debugging. This feature (even if more data is added later on, such as method call counts) is much more analogous to our existing `-r` `--generate-report` functionality which is not under `-d` either.

I preferred the standalone option `-t` for this feature, and I'd be happy to revert to it, but I do not insist. Please advise.