### PR TITLE
firebuild: Allow multiple -d options, merge the flags

### DIFF
--- a/src/firebuild/firebuild.cc
+++ b/src/firebuild/firebuild.cc
@@ -1361,7 +1361,8 @@ int main(const int argc, char *argv[]) {
       break;
 
     case 'd':
-      firebuild::debug_flags = firebuild::parse_debug_flags(optarg);
+      /* Merge the values, so that multiple '-d' options are also allowed. */
+      firebuild::debug_flags |= firebuild::parse_debug_flags(optarg);
       break;
 
     case 'h':


### PR DESCRIPTION
Rationale: I used to have `time` (the bash command) in my firebuild wrapper script, I'd like to replace it with `-d time` so that I always get these statistics.

Plus I'd like to be able to specify additional debug flags from the command line on demand, as I invoke that wrapper script.