### PR TITLE
Drain all fd1 ends of inherited pipes before accepting/shortcutting new processes

### DIFF
--- a/src/firebuild/firebuild.cc
+++ b/src/firebuild/firebuild.cc
@@ -252,11 +252,11 @@ void accept_exec_child(ExecedProcess* proc, int fd_conn,
 
     std::vector<inherited_pipe_t> inherited_pipes = proc->inherited_pipes();
     for (inherited_pipe_t& inherited_pipe : inherited_pipes) {
-      /* There may be incoming data from the parent, drain it. Do it before trying to shortcut. */
-      auto file_fd = proc->get_shared_fd(inherited_pipe.fds[0]);
-      auto pipe = file_fd->pipe();
+      /* There may be incoming data from the (transitive) parent(s), drain it.
+       * Do it before trying to shortcut. */
+      auto pipe = proc->get_fd(inherited_pipe.fds[0])->pipe();
       assert(pipe);
-      pipe->drain_fd1_end(file_fd.get());
+      pipe->drain();
     }
 
     /* Try to shortcut the process. */

--- a/src/firebuild/pipe.h
+++ b/src/firebuild/pipe.h
@@ -205,9 +205,12 @@ class Pipe {
    * Drain one fd1 end corresponding to file_fd and remove file_fd references from ffd2fd1_ends and
    * fd1 end's file_fds if they were present.
    *
-   * @return if file_fd references are (possibly earlier) removed from the pipe
    */
   void drain_fd1_end(FileFD* file_fd);
+  /**
+   * Drain all fd1 ends.
+   */
+  void drain();
   /**
    * Handle closing a pipe end file descriptor in the intercepted process.
    *


### PR DESCRIPTION
This fixes potentially reordering data on the pipe when the new process's
output could be forwarded to the pipe's fd0 before other data already
written by (transitive) parent processes.

Fixes #546.
