### PR TITLE
interceptor: Support dup2(), dup3() to the communication fd

### DIFF
--- a/src/interceptor/CMakeLists.txt
+++ b/src/interceptor/CMakeLists.txt
@@ -13,6 +13,7 @@ add_custom_command (
   DEPENDS generate_interceptors
   tpl.c
   tpl_dlopen.c
+  tpl_dup2.c
   tpl_error.c
   tpl_exec.c
   tpl__exit.c
@@ -24,6 +25,7 @@ add_custom_command (
   tpl_marker_only.c
   tpl_once.c
   tpl_open.c
+  tpl_openat.c
   tpl_pclose.c
   tpl_pipe.c
   tpl_popen.c

--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -952,10 +952,11 @@ generate("int", "dup", "int oldfd",
          after_lines=["copy_notify_on_read_write_state(ret, oldfd);"],
          send_ret_on_success=True)
 generate("int", "dup2", "int oldfd, int newfd",
-         after_lines=["copy_notify_on_read_write_state(newfd, oldfd);"],
+         tpl="dup2",
          msg="dup3")
 generate("int", "dup3", "int oldfd, int newfd, int flags",
-         after_lines=["copy_notify_on_read_write_state(newfd, oldfd);"])
+         tpl="dup2",
+         msg="dup3")
 
 # Intercept access variants
 generate("int", "access", "const char *pathname, int mode",

--- a/src/interceptor/intercept.c
+++ b/src/interceptor/intercept.c
@@ -652,10 +652,9 @@ void *pthread_start_routine_wrapper(void *routine_and_arg) {
 
 /**
  * Set up a supervisor connection
- * @param[in] fd if > -1 remap the connection to that fd
  * @return fd of the connection
  */
-int fb_connect_supervisor(int fd) {
+int fb_connect_supervisor() {
   int conn_ret = -1, conn = ic_orig_socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
 
   assert(conn != -1);
@@ -670,16 +669,6 @@ int fb_connect_supervisor(int fd) {
   if (conn_ret == -1) {
     ic_orig_perror("connect");
     assert(0 && "connection to supervisor failed");
-  }
-
-  if (fd > -1 && conn != fd) {
-    int ret = ic_orig_dup3(conn, fd, O_CLOEXEC);
-    if (ret == -1) {
-      ic_orig_perror("dup3");
-      assert(0 && "connecting standard fds to supervisor failed");
-    }
-    ic_orig_close(conn);
-    conn = fd;
   }
   return conn;
 }
@@ -738,7 +727,7 @@ void fb_init_supervisor_conn() {
   }
   // reconnect to supervisor
   ic_orig_close(fb_sv_conn);
-  fb_sv_conn = fb_connect_supervisor(-1);
+  fb_sv_conn = fb_connect_supervisor();
 }
 
 /**

--- a/src/interceptor/intercept.h
+++ b/src/interceptor/intercept.h
@@ -74,7 +74,7 @@ extern size_t ic_cwd_len;
 extern void reset_fn_infos();
 
 /** Connect to supervisor */
-extern int fb_connect_supervisor(int fd);
+extern int fb_connect_supervisor();
 
 /** Set up main supervisor connection */
 extern void fb_init_supervisor_conn();

--- a/src/interceptor/tpl_dup2.c
+++ b/src/interceptor/tpl_dup2.c
@@ -1,0 +1,50 @@
+{# ------------------------------------------------------------------ #}
+{# Copyright (c) 2022 Interri Kft.                                    #}
+{# This file is an unpublished work. All rights reserved.             #}
+{# ------------------------------------------------------------------ #}
+{# Template for the dup2() and dup3() calls.                          #}
+{# See issue #632 for detailed explanation.                           #}
+{# ------------------------------------------------------------------ #}
+### extends "tpl.c"
+
+### block guard_connection_fd
+  /* Only handle oldfd here, newfd is handled a bit later. */
+  if (oldfd == fb_sv_conn) { errno = EBADF; return -1; }
+### endblock
+
+### block before
+  int fb_sv_conn_new = -1;
+  if (newfd == fb_sv_conn) {
+    /* In order to make this dup2() or dup3() actually happen to the desired newfd
+     * and still be able to talk to the supervisor,
+     * we need to move fb_sv_conn to some other file descriptor. */
+    fb_sv_conn_new = ic_orig_dup(fb_sv_conn);
+    if (fb_sv_conn_new < 0) {
+      /* This dup() failed, which is very unlikely (out of available fds).
+       * There's no hope to succeed with the actual dup2() and still be able to talk
+       * to the supervisor. So just bail out. */
+      if (i_locked) {
+        release_global_lock();
+      }
+      errno = EBADF;
+      return -1;
+    }
+    /* The communication fd has the close-on-exec flag set, and dup() doesn't copy it. */
+    ic_orig_fcntl(fb_sv_conn_new, F_SETFD, FD_CLOEXEC);
+  }
+### endblock
+
+### block after
+  if (newfd == fb_sv_conn) {
+    if (success) {
+      /* The actual dup2() succeeded and thus automatically closed fb_sv_conn.
+       * Use the new fd number from now on for the communication. */
+      fb_sv_conn = fb_sv_conn_new;
+    } else {
+      /* The actual dup2() failed for whatever reason. Close the dupped connection fd. */
+      ic_orig_close(fb_sv_conn_new);
+    }
+  }
+
+  copy_notify_on_read_write_state(newfd, oldfd);
+### endblock


### PR DESCRIPTION
Move the communication to a different file descriptor in this case.

Also remove this obsolete parameter from fb_connect_supervisor().

Fixes #632.