### PR TITLE
firebuild: Allow building firebuild without linking to jemalloc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
     - name: build-in-tree
       run: |
         export PATH=/usr/lib/ccache:$PATH
-        cmake -DCMAKE_BUILD_TYPE=Debug .
+        cmake -DWITH_JEMALLOC=OFF -DCMAKE_BUILD_TYPE=Debug .
         make -j2 check
     - name: test
       run: |
@@ -181,7 +181,7 @@ jobs:
     - name: build-in-tree
       run: |
         export PATH=/usr/lib/ccache:$PATH
-        cmake -DCMAKE_C_FLAGS="-O3 -static-libasan -fsanitize=undefined -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-O3 -static-libasan -fsanitize=undefined -fno-omit-frame-pointer" .
+        cmake -DWITH_JEMALLOC=OFF -DCMAKE_C_FLAGS="-O3 -static-libasan -fsanitize=undefined -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-O3 -static-libasan -fsanitize=undefined -fno-omit-frame-pointer" .
         make -j2 check
         export PATH=${PATH#*ccache:}
     - name: build-vte

--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -4,3 +4,6 @@
 # or result faster hash computation where the system's libxxhash library
 # uses HW acceleration. See: https://bugs.debian.org/977345
 option(ENABLE_XXH_INLINE_ALL "Enable -DXXH_INLINE_ALL" ON)
+
+# Disable linking with jemalloc may help in triaging memory handling issues
+option(WITH_JEMALLOC "Link with jemalloc" ON)

--- a/src/firebuild/CMakeLists.txt
+++ b/src/firebuild/CMakeLists.txt
@@ -7,7 +7,11 @@ set_source_files_properties(firebuild.cc PROPERTIES COMPILE_FLAGS "-DFIREBUILD_V
 find_package(LibConfig REQUIRED)
 find_package(PkgConfig REQUIRED)
 find_package(fmt REQUIRED)
-pkg_check_modules(JEMALLOC REQUIRED jemalloc)
+if (WITH_JEMALLOC)
+  pkg_check_modules(JEMALLOC REQUIRED jemalloc)
+else()
+  set(JEMALLOC_LIBRARIES "")
+endif()
 find_package(tsl-hopscotch-map REQUIRED)
 
 add_custom_command(


### PR DESCRIPTION
This can help triaging memory handling issues. Not using jemalloc results
slightly slower firebuild binary, though.