### PR TITLE
Revert "ci: Use ppa:rbalint/hopscotch-map for fixed hopscotch-map version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ jobs:
     - name: install-deps
       run: |
         sudo add-apt-repository -y -n ppa:rbalint/fmtlib
-        sudo add-apt-repository -y -n ppa:rbalint/hopscotch-map
         sudo add-apt-repository -y -n ppa:rbalint/valgrind
         sudo add-apt-repository -y -u ppa:rbalint/xxhash
         sudo eatmydata apt-get -y install $BUILD_DEPS $TEST_DEPS doxygen valgrind lcov
@@ -138,7 +137,6 @@ jobs:
     - name: install-deps
       run: |
         sudo add-apt-repository -y -n ppa:rbalint/fmtlib
-        sudo add-apt-repository -y -n ppa:rbalint/hopscotch-map
         sudo add-apt-repository -y ppa:rbalint/xxhash
         # work around breaking 18.04's make https://github.com/rbalint/fb/issues/174
         sudo eatmydata apt-get -y install $BUILD_DEPS
@@ -174,7 +172,6 @@ jobs:
         sudo sed -i 's/# deb-src/deb-src/' /etc/apt/sources.list
         sudo apt-get update
         sudo add-apt-repository -y -n ppa:rbalint/fmtlib
-        sudo add-apt-repository -y -n ppa:rbalint/hopscotch-map
         sudo add-apt-repository -y ppa:rbalint/xxhash
         sudo eatmydata apt-get -y install devscripts $BUILD_DEPS $TEST_DEPS
         sudo eatmydata apt-get build-dep vte2.91


### PR DESCRIPTION
Hopscotch-map's suspected bug seems to be in GCC 9, fixed (or not triggered)
in GCC 10.

The bug is also not triggered since commit c1760ab.

This reverts commit 9e13e6543ac8deaeafddfd1e2cc4bbd492e6bda4.

Related to #597.