### PR TITLE
firebuild: Require xxhash (>= 0.8.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
         key: clang-build
     - name: install-deps
       run: |
-        sudo apt-get -qq update
+        sudo add-apt-repository -y ppa:rbalint/xxhash
         sudo eatmydata apt-get -y install clang-tools-12 $BUILD_DEPS
     - name: build
       run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Installation
 
-For Ubuntu earlier than 19.10:
+For Ubuntu earlier than 21.04 (xxhash earlier than 0.8.0):
 
     sudo apt-add-repository ppa:rbalint/xxhash
     

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Build-Depends: bats,
                libfmt-dev,
                libjemalloc-dev,
                libtsl-hopscotch-map-dev,
-               libxxhash-dev,
+               libxxhash-dev (>= 0.8),
                moreutils,
                node-d3,
                python3-jinja2

--- a/src/firebuild/CMakeLists.txt
+++ b/src/firebuild/CMakeLists.txt
@@ -7,6 +7,8 @@ set_source_files_properties(firebuild.cc PROPERTIES COMPILE_FLAGS "-DFIREBUILD_V
 find_package(LibConfig REQUIRED)
 find_package(PkgConfig REQUIRED)
 find_package(fmt REQUIRED)
+# xxh128's algorithm changed and became officially supported in 0.8.0
+pkg_check_modules(XXHASH REQUIRED libxxhash>=0.8.0)
 if (WITH_JEMALLOC)
   pkg_check_modules(JEMALLOC REQUIRED jemalloc)
 else()
@@ -66,7 +68,7 @@ add_executable(firebuild-bin
   fbbstore.cc
   $<TARGET_OBJECTS:common_objs>
   $<TARGET_OBJECTS:fbbcomm_cc>)
-target_link_libraries(firebuild-bin ${LIBCONFIGPP_LIBRARY} ${JEMALLOC_LIBRARIES} xxhash fmt::fmt)
+target_link_libraries(firebuild-bin ${LIBCONFIGPP_LIBRARY} ${JEMALLOC_LIBRARIES} ${XXHASH_LIBRARIES} fmt::fmt)
 target_link_options(firebuild-bin PUBLIC -Wno-array-bounds -Wno-strict-overflow)
 set_target_properties(firebuild-bin
   PROPERTIES INTERPROCEDURAL_OPTIMIZATION True OUTPUT_NAME firebuild)


### PR DESCRIPTION
xxh128 was experimental in 0.7 and the hash value was also different.
To avoid interoperability problems stick to the finalized hash algorithm
with all firebuild builds.