### PR TITLE
Disable interception and shortcutting for processes calling clone()

### DIFF
--- a/src/common/fbbcomm.def
+++ b/src/common/fbbcomm.def
@@ -641,5 +641,9 @@
       # child process id
       (REQUIRED, "pid_t", "pid"),
     ]),
+
+    # disables interception and shortcutting
+    ("clone", []),
+
   ]
 }

--- a/src/firebuild/firebuild.cc
+++ b/src/firebuild/firebuild.cc
@@ -952,6 +952,10 @@ void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf,
           "Changing file timestamps is not supported");
       break;
     }
+    case FBBCOMM_TAG_clone: {
+      proc->exec_point()->disable_shortcutting_bubble_up("clone() is not supported");
+      break;
+    }
     case FBBCOMM_TAG_access:
     case FBBCOMM_TAG_chmod:
     case FBBCOMM_TAG_chown:

--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -1232,9 +1232,8 @@ generate("int", "posix_spawn_file_actions_adddup2", "posix_spawn_file_actions_t 
 
 # Insert a trace marker for clone and pthread_create
 generate("int", "clone", "int (*fn)(void *), void *stack, int flags, void *arg, ...",
-         tpl="marker_only",
-         before_lines=["(void) fn;     /* seemingly unused, actually used via __builtin_apply_args */",
-                       "(void) stack;  /* seemingly unused, actually used via __builtin_apply_args */"])
+         send_msg_on_error=False,
+         tpl="clone")
 generate("int", "pthread_create", "pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void *), void *arg",
          tpl="pthread_create")
 

--- a/src/interceptor/tpl_clone.c
+++ b/src/interceptor/tpl_clone.c
@@ -1,0 +1,19 @@
+{# ------------------------------------------------------------------ #}
+{# Copyright (c) 2020 Interri Kft.                                    #}
+{# This file is an unpublished work. All rights reserved.             #}
+{# ------------------------------------------------------------------ #}
+{# Template for clone().                                              #}
+{# ------------------------------------------------------------------ #}
+### extends "tpl.c"
+
+{% set msg_skip_fields = ["fn", "stack", "flags", "arg"] %}
+
+### block before
+  /* seemingly unused, actually used via __builtin_apply_args */
+  (void) fn;
+  (void) stack;
+  /* clone() can be really tricky to intercept, for example when the cloned process shares
+   * the file descriptor table with the parent (CLONE_FILES). In this case the interceptor
+   * would have to protect two communication fds or implement locking across separate processes. */
+  intercepting_enabled = false;
+### endblock before


### PR DESCRIPTION
Fully supporting clone() would be extremely complicated.

Fixes #644.