### PR TITLE
firebuild: Ignore reading from (or any operations on) /dev/urandom

### DIFF
--- a/etc/firebuild.conf
+++ b/etc/firebuild.conf
@@ -52,7 +52,7 @@ processes = {
 // Ignore operations affecting these files, directories, or any
 // location under these directories.
 ignore_locations = [
-  "/dev/null", "/proc/self", "/dev/zero", "/dev/full", "/dev/tty"
+  "/dev/null", "/proc/self", "/dev/zero", "/dev/urandom", "/dev/full", "/dev/tty"
 ];
 
 // These files, directores, or any location under these directories assumed to be

--- a/src/common/fbbcomm.def
+++ b/src/common/fbbcomm.def
@@ -645,5 +645,13 @@
     # disables interception and shortcutting
     ("clone", []),
 
+
+    # reading from /dev/urandom is allowed (GRND_RANDOM flag not set)
+    ("getrandom", [
+      (OPTIONAL, "int", "flags"),
+      # error no., when ret = -1
+      (OPTIONAL, "int", "error_no"),
+    ]),
+
   ]
 }

--- a/src/firebuild/firebuild.cc
+++ b/src/firebuild/firebuild.cc
@@ -5,6 +5,7 @@
 #include <signal.h>
 #include <getopt.h>
 #include <sys/prctl.h>
+#include <sys/random.h>
 #include <sys/resource.h>
 #include <sys/wait.h>
 #include <sys/socket.h>
@@ -944,6 +945,14 @@ void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf,
     }
     case FBBCOMM_TAG_link: {
       proc->exec_point()->disable_shortcutting_bubble_up("Creating a hard link is not supported");
+      break;
+    }
+    case FBBCOMM_TAG_getrandom: {
+      auto *ic_msg = reinterpret_cast<const FBBCOMM_Serialized_getrandom *>(fbbcomm_buf);
+      const unsigned int flags = fbbcomm_serialized_getrandom_get_flags_with_fallback(ic_msg, 0);
+      if (flags & GRND_RANDOM) {
+        proc->exec_point()->disable_shortcutting_bubble_up("Using /dev/random is not supported");
+      }
       break;
     }
     case FBBCOMM_TAG_futime:

--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -1345,6 +1345,10 @@ skip("sleep", "usleep", "nanosleep", "clock_nanosleep", "pause")
 skip("alarm", "ualarm", "getitimer", "setitimer")
 skip("timer_create", "timer_delete", "timer_settime", "timer_gettime", "timer_getoverrun")
 
+# Getting high entropy randomness should disable shortcutting
+generate("ssize_t", "getrandom", "void* buf, size_t buflen, unsigned int flags",
+         msg_skip_fields = ["buf", "buflen"])
+
 # Querying current time - probably disable shortcutting, let the supervisor decide
 generate("time_t", "time", "time_t *loc",
          success="true",


### PR DESCRIPTION
Bytes from /dev/urandom are historically known for lower quality of randomness,
while this is being debated.

Improves #672.