### PR TITLE
firebuild: Don't intercept processes for which the unix parent could not be found

### DIFF
--- a/test/integration.bats
+++ b/test/integration.bats
@@ -235,8 +235,8 @@ setup() {
   ldd ./test_static 2>&1 | egrep -q '(not a dynamic executable|statically linked)'
 
   for i in 1 2; do
-    result=$(./run-firebuild -- ./test_cmd_system ./test_static)
-    assert_streq "$result" "I am statically linked."
+    result=$(./run-firebuild -- ./test_cmd_system './test_static 3' | tr '\n' ' ')
+    assert_streq "$result" "I am statically linked. end "
     assert_streq "$(strip_stderr stderr)" ""
   done
 }

--- a/test/test_static.c
+++ b/test/test_static.c
@@ -4,8 +4,25 @@
 /* This binary is meant to be statically linked. */
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
-int main() {
-  puts("I am statically linked.\n");
+int main(int argc, char *argv[]) {
+  puts("I am statically linked.");
+  fflush(stdout);
+  if (argc > 1) {
+    int recurse_level = 0;
+    sscanf(argv[1], "%d", &recurse_level);
+    while (recurse_level-- > 0) {
+      pid_t child_pid = fork();
+      if (child_pid > 0) {
+        wait(NULL);
+        return 0;
+      }
+    }
+    return system("echo end");
+  }
   return 0;
 }


### PR DESCRIPTION
Those are presumably children of static binaries which can't be shortcut
or intercepted either.