### PR TITLE
build: Use configure_file() CMake directive instead of file(COPY ...)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,8 +98,7 @@ endif(COVERAGE)
 add_custom_target(style-check
   cpplint --quiet --recursive ${CMAKE_SOURCE_DIR}/src/ ${CMAKE_SOURCE_DIR}/test/)
 
-file(COPY etc/firebuild.conf
-  DESTINATION "${CMAKE_BINARY_DIR}/etc")
+configure_file("${CMAKE_SOURCE_DIR}/etc/firebuild.conf" "${CMAKE_BINARY_DIR}/etc/firebuild.conf" COPYONLY)
 
-install(FILES etc/firebuild.conf DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}")
+install(FILES "${CMAKE_BINARY_DIR}/etc/firebuild.conf" DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}")
 install(FILES data/build-report.html DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/firebuild")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,8 +15,9 @@ function(add_test_binary TEST_BINARY)
   add_dependencies(check "${TEST_BINARY}")
 endfunction()
 
-file(COPY integration.bats test_parallel_make.Makefile test_symbols
-  DESTINATION "${CMAKE_BINARY_DIR}/test")
+foreach(TESTFILE integration.bats test_parallel_make.Makefile test_symbols)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/${TESTFILE}" "${CMAKE_CURRENT_BINARY_DIR}/${TESTFILE}" COPYONLY)
+endforeach()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test_helper.bash.in ${CMAKE_CURRENT_BINARY_DIR}/test_helper.bash)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/run-firebuild.in ${CMAKE_CURRENT_BINARY_DIR}/run-firebuild)

--- a/test/run-firebuild.in
+++ b/test/run-firebuild.in
@@ -3,7 +3,7 @@
 . @CMAKE_CURRENT_BINARY_DIR@/test_helper.bash
 
 env FIREBUILD_DATA_DIR="@CMAKE_SOURCE_DIR@/data" $FIREBUILD_PREFIX_CMD firebuild \
-  -c @CMAKE_SOURCE_DIR@/etc/firebuild.conf \
+  -c @CMAKE_BINARY_DIR@/etc/firebuild.conf \
   -o 'env_vars.pass_through += "GCOV_PREFIX"' \
   -o 'env_vars.pass_through += "GCOV_PREFIX_STRIP"' \
   -o "ignore_locations += \"$GCOV_PREFIX\"" \


### PR DESCRIPTION
to let modifications in the source take place in the binary directory, too.

Fixes #590.