### PR TITLE
interceptor: Don't crash trying to make a NULL file name passed to statx canonical

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
     - name: build-in-tree
       run: |
         export PATH=/usr/lib/ccache:$PATH
-        cmake -DWITH_JEMALLOC=OFF -DCMAKE_C_FLAGS="-O3 -static-libasan -fsanitize=undefined -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-O3 -static-libasan -fsanitize=undefined -fno-omit-frame-pointer" .
+        cmake -DWITH_JEMALLOC=OFF -DCMAKE_C_FLAGS="-O3 -static-libasan -fsanitize=undefined -fno-omit-frame-pointer -DSKIP_TEST_NULL_NONNULL_PARAMS=1" -DCMAKE_CXX_FLAGS="-O3 -static-libasan -fsanitize=undefined -fno-omit-frame-pointer" .
         make -j2 check
         export PATH=${PATH#*ccache:}
     - name: build-vte

--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -944,6 +944,7 @@ generate("int", "__fxstatat64", "int ver, int dirfd, const char *filename, struc
 generate("int", "statx", "int dirfd, const char *filename, int flags, unsigned int mask, struct statx *statx_buf",
          msg="stat",
          msg_skip_fields=["filename", "flags", "mask", "statx_buf"],
+         send_msg_condition="ret != -1 || errno != EFAULT",
          msg_add_fields=["if (flags & AT_SYMLINK_NOFOLLOW) fbbcomm_builder_stat_set_link(&ic_msg, true);",
                          "BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(stat, dirfd, filename);"])
 # Treat isfdtype() as a fstat()

--- a/src/interceptor/tpl.c
+++ b/src/interceptor/tpl.c
@@ -226,7 +226,7 @@ ic_orig_{{ func }} = ({{ rettype }}(*)({{ sig_str }})) dlsym(RTLD_NEXT, "{{ func
 ###       block send_msg
 ###         if msg
   /* Maybe notify the supervisor */
-  if (i_am_intercepting && {{ send_msg_condition }}) {
+  if (i_am_intercepting && ({{ send_msg_condition }})) {
     FBBCOMM_Builder_{{ msg }} ic_msg;
     fbbcomm_builder_{{ msg }}_init(&ic_msg);
 

--- a/test/test_file_ops.c
+++ b/test/test_file_ops.c
@@ -101,6 +101,15 @@ int main() {
     exit(1);
   }
 
+/* Allow skipping this test since the ASAN & UBSAN build finds out that this code is incorrect. */
+#ifndef SKIP_TEST_NULL_NONNULL_PARAMS
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnonnull"
+  /* Call statx with invalid parameters, like cargo does. */
+  statx(0, NULL, 0, STATX_ALL, NULL);
+#pragma GCC diagnostic pop
+#endif
+
   /* Run part 2. */
   if (system("./test_file_ops_2") != 0) {
     exit(1);


### PR DESCRIPTION
Cargo calls statx with NULL file name, which crashed the interceptor:
statx(0, NULL, AT_STATX_SYNC_AS_STAT, STATX_ALL, NULL) = -1 EFAULT (Bad address)