### PR TITLE
fbb: Add getter for scalar's pointer, returning NULL if the field is unset

### DIFF
--- a/src/common/fbb/README_FBB.txt
+++ b/src/common/fbb/README_FBB.txt
@@ -8,6 +8,10 @@ It is tailored to Firebuild's needs, including these features:
  - high performance,
  - async-signal-safety (e.g. doesn't malloc) (*).
 
+On the other hand, it does *NOT* support the following typical features:
+ - architecture independence,
+ - backwards compatibility with earlier FBB defitions.
+
 (*) The basic plain C API, including setters, getters, serializing etc.
 does not perform malloc. However, the debugging methods, and the
 convenience C++ API might malloc.
@@ -324,9 +328,12 @@ Nothing special. Setter:
 
     fbbns_builder_foo_set_myuint(&bldr, 42);
 
-Getter:
+Getter for the value or its address:
 
     uint16_t val = fbbns_serialized_foo_get_myuint(msg);
+
+    const uint16_t *ptr = fbbns_serialized_foo_get_myuint_ptr(msg);
+    /* ptr is non-NULL */
 
 
 ### Optional scalar
@@ -348,9 +355,14 @@ error and results in assertion failure.
       uint16_t val = fbbns_serialized_foo_get_myuint(msg);
     }
 
-However, you can use this convenience wrapper which returns the given
-fallback value if the field was unset. Needless to say, it cannot tell
-if the field was actually set to that fallback value.
+Or get a pointer, which returns NULL if the value wasn't set:
+
+    const uint16_t *ptr = fbbns_serialized_foo_get_myuint_ptr(msg);
+    if (ptr == NULL) { ... }
+
+Or you can use this convenience wrapper which returns the given fallback
+value if the field was unset. Needless to say, it cannot tell if the
+field was actually set to that fallback value.
 
     uint16_t val = fbbns_serialized_foo_get_myuint_with_fallback(msg, 100);
 

--- a/src/common/fbb/tpl.h
+++ b/src/common/fbb/tpl.h
@@ -459,6 +459,20 @@ static inline {{ type }} {{ ns }}_builder_{{ msg }}_get_{{ var }}(const {{ NS }}
 ###         endif
   return msg->wire.{{ var }};
 }
+/*
+ * Builder getter - pointer to required or optional scalar
+ * {{ type }} {{ var }}
+ */
+static inline const {{ type }} *{{ ns }}_builder_{{ msg }}_get_{{ var }}_ptr(const {{ NS }}_Builder_{{ msg }} *msg) {
+  assert(msg->wire.{{ ns }}_tag == {{ NS }}_TAG_{{ msg }});
+
+###         if quant == OPTIONAL
+  if (!msg->wire.has_{{ var }}) {
+    return NULL;
+  }
+###         endif
+  return &msg->wire.{{ var }};
+}
 ###         if quant == OPTIONAL
 /*
  * Builder getter - optional scalar with fallback default
@@ -677,6 +691,20 @@ static inline {{ type }} {{ ns }}_serialized_{{ msg }}_get_{{ var }}(const {{ NS
   assert(msg->has_{{ var }});
 ###         endif
   return msg->{{ var }};
+}
+/*
+ * Serialized getter - pointer to required or optional scalar
+ * {{ type }} {{ var }}
+ */
+static inline const {{ type }} *{{ ns }}_serialized_{{ msg }}_get_{{ var }}_ptr(const {{ NS }}_Serialized_{{ msg }} *msg) {
+  assert(msg->{{ ns }}_tag == {{ NS }}_TAG_{{ msg }});
+
+###         if quant == OPTIONAL
+  if (!msg->has_{{ var }}) {
+    return NULL;
+  }
+###         endif
+  return &msg->{{ var }};
 }
 ###         if quant == OPTIONAL
 /*


### PR DESCRIPTION
This dropped out as a byproduct of the WIP stat stuff. Probably I won't use it now because I ran into nasty casting issues between the raw checksum and the Hash object. Anyway, I think it's nice to have this feature, might come handy in the future.