### PR TITLE
Ignore communication with GNU Make and Cargo jobservers

### DIFF
--- a/etc/firebuild.conf
+++ b/etc/firebuild.conf
@@ -11,8 +11,8 @@ env_vars = {
   fingerprint_skip = [ "MAKE_TERMOUT", "MAKE_TERMERR" ];
 
   // The folloving environment variables are pre-set to the values configured below.
-  // Note that FB_SOCKET, FB_READ_ONLY_LOCATIONS, FB_IGNORE_LOCATIONS and LD_PRELOAD
-  // (DYLD_INSERT_LIBRARIES and DYLD_FORCE_FLAT_NAMESPACE on OS X)
+  // Note that FB_SOCKET, FB_READ_ONLY_LOCATIONS, FB_IGNORE_LOCATIONS, FB_JOBSERVER_USERS
+  // and LD_PRELOAD (DYLD_INSERT_LIBRARIES and DYLD_FORCE_FLAT_NAMESPACE on OS X)
   // are also set by firebuild internally.
   // The variables should be in "NAME=value" format.
   preset = [
@@ -89,6 +89,18 @@ processes = {
     "bash",
     "dash",
     "sh"
+  ];
+  // Programs that use Make's or a similar jobserver.
+  // Firebuild ignores the below programs' communication over jobserver fds to allow shortcutting
+  // them.
+  // Only the file name without the directory name can be listed here,
+  // for example list "rustc" instead of "/usr/bin/rustc".
+  jobserver_users = [
+    "cargo",
+    // Make is not shortcut by default, thus its communication over the jobserver fds does not make
+    // a difference.
+    // "make",
+    "rustc"
   ];
 };
 

--- a/src/common/fbbcomm.def
+++ b/src/common/fbbcomm.def
@@ -115,6 +115,9 @@
       # umask
       (REQUIRED, "mode_t", "umask"),
       # full path of the binary, it is expected to be in absolute and canonical form
+      # fds (2: [<read fd>, <write fd>]) likely being used by GNU Make's jobserver
+      (ARRAY, "int", "jobserver_fds"),
+      # full path of the binary
       (OPTIONAL, STRING, "executable"),
       # original executed_path converted to canonical and absolute path
       # set only when the original executed path is different from executable

--- a/src/common/firebuild_common.c
+++ b/src/common/firebuild_common.c
@@ -75,6 +75,24 @@ void cstring_view_array_deep_free(cstring_view_array *array) {
   free(array->p);
 }
 
+bool is_in_sorted_cstring_view_array(const char *str, const ssize_t len,
+                                     const cstring_view_array *array) {
+  for (int i = 0; i < array->len; i++) {
+    const char * const entry = array->p[i].c_str;
+    const ssize_t entry_len = array->p[i].length;
+    if (len != entry_len) {
+      continue;
+    }
+    const int memcmp_res = memcmp(entry, str, len);
+    if (memcmp_res < 0) {
+      continue;
+    } else {
+      return memcmp_res == 0;
+    }
+  }
+  return false;
+}
+
 void voidp_array_init(voidp_array *array) {
   memset(array, 0, sizeof(*array));
 }

--- a/src/common/firebuild_common.h
+++ b/src/common/firebuild_common.h
@@ -59,6 +59,9 @@ void cstring_view_array_deep_free(cstring_view_array *array);
 bool is_cstring_view_array_full(cstring_view_array *array);
 void cstring_view_array_append_noalloc(cstring_view_array *array, char *s);
 
+bool is_in_sorted_cstring_view_array(const char *str, const ssize_t len,
+                                     const cstring_view_array *array);
+
 #define STATIC_CSTRING_VIEW_ARRAY(name, size)       \
   cstring_view name##_ptrs[size] = {0};             \
   cstring_view_array name = {name##_ptrs, 0, size}

--- a/src/firebuild/config.cc
+++ b/src/firebuild/config.cc
@@ -457,6 +457,13 @@ char** get_sanitized_env(libconfig::Config *cfg, const char *fb_conn_string,
   export_sorted_locations(cfg, "read_only_locations", "FB_READ_ONLY_LOCATIONS", &env);
   export_sorted_locations(cfg, "ignore_locations", "FB_IGNORE_LOCATIONS", &env);
 
+  try {
+    const libconfig::Setting& locations_setting = root["processes"]["jobserver_users"];
+    export_sorted(locations_setting, "FB_JOBSERVER_USERS", &env);
+  } catch(libconfig::SettingNotFoundException&) {
+    /* Configuration setting may be missing. This is OK. */
+  }
+
   const char *ld_preload_value = getenv(LD_PRELOAD);
   if (ld_preload_value) {
     env[LD_PRELOAD] = LIBFIREBUILD_SO ":" + std::string(ld_preload_value);

--- a/src/firebuild/execed_process.h
+++ b/src/firebuild/execed_process.h
@@ -92,6 +92,19 @@ class ExecedProcess : public Process {
   ForkedProcess* fork_point() {return fork_point_;}
   const ForkedProcess* fork_point() const {return fork_point_;}
   void set_parent(Process *parent);
+  /**
+   * Set jobserver fds if they are reasonably small and fit in the member's type.
+   */
+  void maybe_set_jobserver_fds(int fd_r, int fd_w) {
+    if (fd_w >= 0 && fd_r <= INT16_MAX) {
+      jobserver_fd_r_ = fd_r;
+    }
+    if (fd_w >= 0 && fd_w <= INT16_MAX) {
+      jobserver_fd_w_ = fd_w;
+    }
+  }
+  int jobserver_fd_r() const {return jobserver_fd_r_;}
+  int jobserver_fd_w() const {return jobserver_fd_w_;}
   bool been_waited_for() const;
   void set_been_waited_for();
   void add_utime_u(int64_t t) {utime_u_ += t;}
@@ -240,6 +253,8 @@ class ExecedProcess : public Process {
  private:
   bool can_shortcut_:1;
   bool was_shortcut_:1;
+  int16_t jobserver_fd_r_ = -1;
+  int16_t jobserver_fd_w_ = -1;
   /** If points to this (self), the process can be shortcut.
       Otherwise the process itself is not shortcutable, but the ancestor is, if the ancestor's
       maybe_shortcutable_ancestor points at itself, etc. */

--- a/src/firebuild/message_processor.cc
+++ b/src/firebuild/message_processor.cc
@@ -156,8 +156,14 @@ void MessageProcessor::accept_exec_child(ExecedProcess* proc, int fd_conn,
 
       // TODO(rbalint) skip reopening fd if parent's other forked processes closed the fd
       // without writing to it
+      const int jobserver_fd_w = proc->jobserver_fd_w();
       for (inherited_file_t& inherited_file : inherited_files) {
         if (inherited_file.type == FD_PIPE_OUT) {
+          if (inherited_file.fds[0] == jobserver_fd_w
+              && inherited_file.fds.size() == 1) {
+            /* Skip reopening the jobserver pipe. */
+            continue;
+          }
           auto file_fd_old = proc->get_shared_fd(inherited_file.fds[0]);
           auto pipe = file_fd_old->pipe();
           assert(pipe);

--- a/src/firebuild/process_factory.cc
+++ b/src/firebuild/process_factory.cc
@@ -73,6 +73,12 @@ ProcessFactory::getExecedProcess(const FBBCOMM_Serialized_scproc_query *const ms
   FB_DEBUG(FB_DEBUG_PROC, "- lib = " + d(msg->get_libs_as_vector()));
   FB_DEBUG(FB_DEBUG_PROC, "- umask = " + d(e->umask()));
 
+  if (fbbcomm_serialized_scproc_query_get_jobserver_fds_count(msg) == 2) {
+    const int* jobserver_fds = fbbcomm_serialized_scproc_query_get_jobserver_fds(msg);
+    e->maybe_set_jobserver_fds(jobserver_fds[0], jobserver_fds[1]);
+    FB_DEBUG(FB_DEBUG_PROC, "- jobserver_fd_r = " + d(e->jobserver_fd_r()));
+    FB_DEBUG(FB_DEBUG_PROC, "- jobserver_fd_w = " + d(e->jobserver_fd_w()));
+  }
   return e;
 }
 

--- a/src/interceptor/intercept.c
+++ b/src/interceptor/intercept.c
@@ -541,29 +541,29 @@ static int cmpstringpp(const void *p1, const void *p2) {
   return strcmp(* (char * const *) p1, * (char * const *) p2);
 }
 
-/** Store file locations for which files open() does not need an ACK. */
-static void store_locations(const char* env_var, cstring_view_array *locations,
-                            char * locations_env_buf, size_t buffer_size) {
-  char* env_locations = getenv(env_var);
-  if (env_locations) {
-    strncpy(locations_env_buf, env_locations, buffer_size);
-    const size_t env_locations_len = strlen(env_locations);
-    if (env_locations_len + 1 > buffer_size) {
-      /* Trim to the fitting parts. The locations are used only for improving
+/** Store from entries from environment variable. */
+static void store_entries(const char* env_var, cstring_view_array *entries,
+                          char * entries_env_buf, size_t buffer_size) {
+  char* env_entries = getenv(env_var);
+  if (env_entries) {
+    strncpy(entries_env_buf, env_entries, buffer_size);
+    const size_t env_entries_len = strlen(env_entries);
+    if (env_entries_len + 1 > buffer_size) {
+      /* Trim to the fitting parts. The entries are used only for improving
        * performance and the space is allocated statically. */
-      locations_env_buf[buffer_size - 1] = '\0';
-      char * last_separator = strrchr(locations_env_buf, ':');
+      entries_env_buf[buffer_size - 1] = '\0';
+      char * last_separator = strrchr(entries_env_buf, ':');
       if (!last_separator) {
         /* This is a quite long single path that may be incomplete, thus ignore it. */
-        locations_env_buf[0] = '\0';
+        entries_env_buf[0] = '\0';
       } else {
         /* Drop the possibly incomplete path after the last separator.*/
         *last_separator = '\0';
       }
     }
-    char *prefix = locations_env_buf;
-    /* Process all locations that fit location without reallocation. */
-    while (prefix && !is_cstring_view_array_full(locations)) {
+    char *prefix = entries_env_buf;
+    /* Process all entries that fit location without reallocation. */
+    while (prefix && !is_cstring_view_array_full(entries)) {
       char *next_prefix = strchr(prefix, ':');
       if (next_prefix) {
         *next_prefix = '\0';
@@ -571,7 +571,7 @@ static void store_locations(const char* env_var, cstring_view_array *locations,
       }
       /* Skip "". */
       if (*prefix != '\0') {
-        cstring_view_array_append_noalloc(locations, prefix);
+        cstring_view_array_append_noalloc(entries, prefix);
         prefix = next_prefix;
       }
     }
@@ -870,10 +870,10 @@ static void fb_ic_init() {
     insert_trace_markers = true;
   }
 
-  store_locations("FB_READ_ONLY_LOCATIONS", &read_only_locations, read_only_locations_env_buf,
-                  sizeof(read_only_locations_env_buf));
-  store_locations("FB_IGNORE_LOCATIONS", &ignore_locations, ignore_locations_env_buf,
-                  sizeof(ignore_locations_env_buf));
+  store_entries("FB_READ_ONLY_LOCATIONS", &read_only_locations, read_only_locations_env_buf,
+                sizeof(read_only_locations_env_buf));
+  store_entries("FB_IGNORE_LOCATIONS", &ignore_locations, ignore_locations_env_buf,
+                sizeof(ignore_locations_env_buf));
 
 #ifndef __mips__
   /* We use an uint64_t as bitmap for delayed signals. Make sure it's okay.

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -77,7 +77,7 @@ setup() {
   for i in 1 2; do
     # clean up previous run
     make -s -f test_parallel_make.Makefile clean
-    result=$(./run-firebuild -- make -s -j8 -f test_parallel_make.Makefile)
+    result=$(./run-firebuild -o 'processes.jobserver_users += "make"' -- make -s -j8 -f test_parallel_make.Makefile)
     assert_streq "$result" "ok"
     assert_streq "$(strip_stderr stderr)" ""
     result=$(./run-firebuild -s)


### PR DESCRIPTION
This lets shortcutting processes that read tokens from the jobserver.

I need to verify that it works with big projects, where jobserver is really in use.