### PR TITLE
supervisor: Clean up the optional struct stat's role in hashing methods

### DIFF
--- a/src/firebuild/blob_cache.h
+++ b/src/firebuild/blob_cache.h
@@ -22,7 +22,7 @@ class BlobCache {
 
   bool store_file(const FileName *path,
                   int fd_src,
-                  struct stat64 *stat_ptr,
+                  const struct stat64 *stat_ptr,
                   Hash *key_out);
   bool move_store_file(const std::string &path,
                        int fd,

--- a/src/firebuild/hash.cc
+++ b/src/firebuild/hash.cc
@@ -50,15 +50,15 @@ void Hash::set_from_data(const void *data, ssize_t size) {
  * @param is_dir_out Optionally store here whether fd refers to a directory
  * @return Whether succeeded
  */
-bool Hash::set_from_fd(int fd, struct stat64 *stat_ptr, bool *is_dir_out) {
+bool Hash::set_from_fd(int fd, const struct stat64 *stat_ptr, bool *is_dir_out) {
   TRACKX(FB_DEBUG_HASH, 0, 1, Hash, this, "fd=%d", fd);
 
-  struct stat64 st_local, *st;
-  st = stat_ptr ? stat_ptr : &st_local;
-  if (!stat_ptr && fstat64(fd, st) == -1) {
+  struct stat64 st_local;
+  if (!stat_ptr && fstat64(fd, &st_local) == -1) {
     perror("fstat");
     return false;
   }
+  const struct stat64 *st = stat_ptr ? stat_ptr : &st_local;
 
   if (S_ISREG(st->st_mode)) {
     /* Compute the hash of a regular file. */

--- a/src/firebuild/hash.h
+++ b/src/firebuild/hash.h
@@ -51,7 +51,7 @@ class Hash {
   static const size_t kAsciiLength = 22;
 
   void set_from_data(const void *data, ssize_t size);
-  bool set_from_fd(int fd, struct stat64 *stat_ptr, bool *is_dir_out);
+  bool set_from_fd(int fd, const struct stat64 *stat_ptr, bool *is_dir_out);
   bool set_from_file(const FileName *filename, bool *is_dir_out = NULL);
 
   void set(XXH128_hash_t);

--- a/src/firebuild/hash_cache.h
+++ b/src/firebuild/hash_cache.h
@@ -39,10 +39,10 @@ class HashCache {
    * @param[out]     hash to retrive/calculate
    * @param[out]     is_dir path is a dir
    * @param fd       when set to a valid fd the file is read from there
-   * @param stat_ptr when fd is set this parameter is set to the fd's stat data
+   * @param stat_ptr optionally the file's parameters already stat()'ed
    */
   bool get_hash(const FileName* path, Hash *hash, bool *is_dir = NULL, int fd = -1,
-                struct stat64 *stat_ptr = NULL);
+                const struct stat64 *stat_ptr = NULL);
 
   /**
    * Calculate hash of a regular file on the path, and update the hash cache.
@@ -53,9 +53,9 @@ class HashCache {
    * @param path     file's path
    * @param[out]     hash to retrive/calculate
    * @param fd       the file is read from there
-   * @param stat_ptr when fd is set this parameter is set to the fd's stat data
+   * @param stat_ptr optionally the file's parameters already stat()'ed
    */
-  bool store_and_get_hash(const FileName* path, Hash *hash, int fd, struct stat64 *stat_ptr);
+  bool store_and_get_hash(const FileName* path, Hash *hash, int fd, const struct stat64 *stat_ptr);
 
  private:
   tsl::hopscotch_map<const FileName*, HashCacheEntry> db_ = {};
@@ -72,7 +72,7 @@ class HashCache {
    * @param stat_ptr when fd is set this parameter is set to the fd's stat data
    * @param store    whether to store the file in the blob cache
    */
-  HashCacheEntry* get_entry(const FileName* path, int fd = -1, struct stat64 *stat_ptr = NULL,
+  HashCacheEntry* get_entry(const FileName* path, int fd = -1, const struct stat64 *stat_ptr = NULL,
                             bool store = false);
 
   DISALLOW_COPY_AND_ASSIGN(HashCache);


### PR DESCRIPTION
(no functional change, just adding `const` to make it cleaner that the methods don't update that field.)