### PR TITLE
supervisor: Factor out the hash from FileInitialState to a separate variable

### DIFF
--- a/src/firebuild/execed_process.cc
+++ b/src/firebuild/execed_process.cc
@@ -326,8 +326,7 @@ bool ExecedProcess::register_file_usage(const FileName *name,
      * modifications to apply currently, and then we propagate this upwards to be applied.
      */
     /* If hash is not stored yet it may need to be. */
-    bool read_again = !fu->written()
-        && (fu->initial_state() != ISDIR_WITH_HASH && fu->initial_state() != ISREG_WITH_HASH);
+    bool read_again = !fu->written() && !fu->initial_hash_known();
     const FileUsage *fu_change = FileUsage::Get(actual_file, action, flags, error, read_again);
     if (!fu_change) {
       /* Error */
@@ -639,7 +638,8 @@ void ExecedProcess::export2js(const unsigned int level,
 
   fprintf(stream, "%s fcreated: [", indent);
   for (auto& ffu : ordered_file_usages) {
-    if (ffu.usage->initial_state() != ISREG_WITH_HASH && ffu.usage->written()) {
+    bool isreg_with_hash = ffu.usage->initial_state() == ISREG && ffu.usage->initial_hash_known();
+    if (!isreg_with_hash && ffu.usage->written()) {
       fprintf(stream, "\"%s\",", ffu.file->c_str());
     }
   }
@@ -647,7 +647,8 @@ void ExecedProcess::export2js(const unsigned int level,
 
   fprintf(stream, "%s fmodified: [", indent);
   for (auto& ffu : ordered_file_usages) {
-    if (ffu.usage->initial_state() == ISREG_WITH_HASH && ffu.usage->written()) {
+    bool isreg_with_hash = ffu.usage->initial_state() == ISREG && ffu.usage->initial_hash_known();
+    if (isreg_with_hash && ffu.usage->written()) {
       fprintf(stream, "\"%s\",", ffu.file->c_str());
     }
   }
@@ -655,7 +656,8 @@ void ExecedProcess::export2js(const unsigned int level,
 
   fprintf(stream, "%s fread: [", indent);
   for (auto& ffu : ordered_file_usages) {
-    if (ffu.usage->initial_state() == ISREG_WITH_HASH && !ffu.usage->written()) {
+    bool isreg_with_hash = ffu.usage->initial_state() == ISREG && ffu.usage->initial_hash_known();
+    if (isreg_with_hash && !ffu.usage->written()) {
       fprintf(stream, "\"%s\",", ffu.file->c_str());
     }
   }
@@ -663,7 +665,8 @@ void ExecedProcess::export2js(const unsigned int level,
 
   fprintf(stream, "%s fnotf: [", indent);
   for (auto& ffu : ordered_file_usages) {
-    if (ffu.usage->initial_state() != ISREG_WITH_HASH && !ffu.usage->written()) {
+    bool isreg_with_hash = ffu.usage->initial_state() == ISREG && ffu.usage->initial_hash_known();
+    if (!isreg_with_hash && !ffu.usage->written()) {
       fprintf(stream, "\"%s\",", ffu.file->c_str());
     }
   }

--- a/src/firebuild/fbbstore.def
+++ b/src/firebuild/fbbstore.def
@@ -31,11 +31,11 @@
     ("file", [
       # file path, absolute or relative
       (REQUIRED, STRING,          "path"),
-      # checksum (binary) of the file content, empty if file is not found
-      (REQUIRED, "XXH128_hash_t", "hash"),
+      # checksum (binary) of the file content, if relevant and known
+      (OPTIONAL, "XXH128_hash_t", "hash"),
       # TODO add alternate hash values generated after preprocessing the file
       # with programs keeping the semantic content (e.g. removing white spaces)
-      #(REQUIRED, "XXH128_hash_t", "alt_hash"),
+      #(OPTIONAL, "XXH128_hash_t", "alt_hash"),
 
       # last modification time - FIXME in what unit?
       #(OPTIONAL, "long",          "mtime"),
@@ -66,12 +66,10 @@
     # that matches the current world.
     ("process_inputs", [
       # Files that are opened for reading, with various results.
-      (ARRAY, FBB,    "path_isreg_with_hash"),         # tag "file"
-      (ARRAY, FBB,    "system_path_isreg_with_hash"),  # tag "file"
-      (ARRAY, STRING, "path_isreg"),
-      (ARRAY, FBB,    "path_isdir_with_hash"),         # tag "file"
-      (ARRAY, FBB,    "system_path_isdir_with_hash"),  # tag "file"
-      (ARRAY, STRING, "path_isdir"),
+      (ARRAY, FBB,    "path_isreg"),                   # tag "file"
+      (ARRAY, FBB,    "system_path_isreg"),            # tag "file"
+      (ARRAY, FBB,    "path_isdir"),                   # tag "file"
+      (ARRAY, FBB,    "system_path_isdir"),            # tag "file"
       (ARRAY, STRING, "path_notexist_or_isreg"),
       (ARRAY, STRING, "path_notexist_or_isreg_empty"),
       (ARRAY, STRING, "path_notexist"),


### PR DESCRIPTION
Please take a look.

WIP only because of `export2js()`. The grouping based on `fcreated` / `fmodified` / `fread` / `fnotf` is already outdated according to our model and doesn't really make sense to maintain. What do you want to see instead? (Can we just simply remove this code? :))