### PR TITLE
supervisor: Clean up symlink handling

### DIFF
--- a/src/common/debug_sysflags.c
+++ b/src/common/debug_sysflags.c
@@ -66,7 +66,8 @@ extern "C" {
   }
 
 /**
- * Debug-print the 'flags' parameter of an open() call.
+ * Debug-print O_* flags, as usually seen in the 'flags' parameter of dup3(), open(), pipe2(),
+ * posix_spawn_file_actions_addopen() etc. calls.
  */
 void debug_open_flags(FILE *f, int flags) {
   DEBUG_BITMAP_START(f, flags)
@@ -98,6 +99,25 @@ void debug_open_flags(FILE *f, int flags) {
   DEBUG_BITMAP_FLAG(f, flags, O_SYNC)
   DEBUG_BITMAP_FLAG(f, flags, O_TMPFILE)
   DEBUG_BITMAP_FLAG(f, flags, O_TRUNC)
+  DEBUG_BITMAP_END_HEX(f, flags)
+}
+
+/**
+ * Debug-print AT_* flags, as usually seen in the 'flags' parameter of execveat(), faccessat(),
+ * fchmodat(), fchownat(), fstatat(), linkat(), statx(), unlinkat(), utimensat() etc. calls.
+ */
+void debug_at_flags(FILE *f, int flags) {
+  DEBUG_BITMAP_START(f, flags)
+  DEBUG_BITMAP_FLAG(f, flags, AT_EMPTY_PATH)
+  DEBUG_BITMAP_FLAG(f, flags, AT_NO_AUTOMOUNT)
+  DEBUG_BITMAP_FLAG(f, flags, AT_RECURSIVE)
+  DEBUG_BITMAP_FLAG(f, flags, AT_REMOVEDIR)
+  DEBUG_BITMAP_FLAG(f, flags, AT_STATX_DONT_SYNC)
+  DEBUG_BITMAP_FLAG(f, flags, AT_STATX_FORCE_SYNC)
+  DEBUG_BITMAP_FLAG(f, flags, AT_STATX_SYNC_AS_STAT)
+  DEBUG_BITMAP_FLAG(f, flags, AT_STATX_SYNC_TYPE)
+  DEBUG_BITMAP_FLAG(f, flags, AT_SYMLINK_FOLLOW)
+  DEBUG_BITMAP_FLAG(f, flags, AT_SYMLINK_NOFOLLOW)
   DEBUG_BITMAP_END_HEX(f, flags)
 }
 

--- a/src/common/debug_sysflags.h
+++ b/src/common/debug_sysflags.h
@@ -17,6 +17,7 @@ extern "C" {
 #endif
 
 void debug_open_flags(FILE *f, int flags);
+void debug_at_flags(FILE *f, int flags);
 void debug_fcntl_cmd(FILE *f, int cmd);
 void debug_fcntl_arg_or_ret(FILE *f, int cmd, int arg);
 void debug_error_no(FILE *f, int error_no);

--- a/src/common/fbbcomm.def
+++ b/src/common/fbbcomm.def
@@ -34,6 +34,15 @@
       fprintf(f, "\\"");
     }
 
+    /* Debugger method for int fields that represent AT_* flags. */
+    static void fbbcomm_debug_at_flags(FILE *f, int flags, bool is_serialized, const void *fbb) {
+      (void)is_serialized;  /* unused */
+      (void)fbb;  /* unused */
+      fprintf(f, "\\"");
+      debug_at_flags(f, flags);
+      fprintf(f, "\\"");
+    }
+
     /* Debugger method for int fields that represent fcntl()'s F_* command. */
     static void fbbcomm_debug_fcntl_cmd(FILE *f, int cmd, bool is_serialized, const void *fbb) {
       (void)is_serialized;  /* unused */
@@ -245,7 +254,7 @@
       # access mode
       (OPTIONAL, "int", "mode"),
       # flags
-      (OPTIONAL, "int", "flags"),
+      (OPTIONAL, "int", "flags", "fbbcomm_debug_at_flags"),
       # error no., when ret = -1
       (OPTIONAL, "int", "error_no"),
     ]),
@@ -258,7 +267,7 @@
       # path to file
       (OPTIONAL, STRING, "filename"),
       # it could be lstat() encoded as AT_SYMLINK_NOFOLLOW or fstatat(..., flags)
-      (OPTIONAL, "int", "flags"),
+      (OPTIONAL, "int", "flags", "fbbcomm_debug_at_flags"),
       # error no., when ret = -1
       (OPTIONAL, "int", "error_no"),
     ]),
@@ -305,7 +314,7 @@
       # mode
       (OPTIONAL, "mode_t", "mode"),
       # flags for fchmodat()
-      (OPTIONAL, "int", "flags"),
+      (OPTIONAL, "int", "flags", "fbbcomm_debug_at_flags"),
       # it was actually lchmod() or fchmodat(..., AT_SYMLINK_NOFOLLOW), so don't follow symlink
       (OPTIONAL, "bool", "link"),
       # error no., when ret = -1
@@ -331,7 +340,7 @@
       # gid
       (OPTIONAL, "gid_t", "group"),
       # flags for fchownat()
-      (OPTIONAL, "int", "flags"),
+      (OPTIONAL, "int", "flags", "fbbcomm_debug_at_flags"),
       # it was actually lchown() or fchownat(..., AT_SYMLINK_NOFOLLOW), so don't follow symlink
       (OPTIONAL, "bool", "link"),
       # error no., when ret = -1
@@ -346,7 +355,7 @@
       # gid
       (OPTIONAL, "gid_t", "group"),
       # flags for fchownat()
-      (OPTIONAL, "int", "flags"),
+      (OPTIONAL, "int", "flags", "fbbcomm_debug_at_flags"),
       # error no., when ret = -1
       (OPTIONAL, "int", "error_no"),
     ]),
@@ -357,7 +366,7 @@
       # path name
       (OPTIONAL, STRING, "pathname"),
       # flags for unlinkat()
-      (OPTIONAL, "int", "flags"),
+      (OPTIONAL, "int", "flags", "fbbcomm_debug_at_flags"),
       # error no., when ret = -1
       (OPTIONAL, "int", "error_no"),
     ]),
@@ -372,7 +381,7 @@
       # new file path
       (OPTIONAL, STRING, "newpath"),
       # flags for linkat()
-      (OPTIONAL, "int", "flags"),
+      (OPTIONAL, "int", "flags", "fbbcomm_debug_at_flags"),
       # error no., when ret = -1
       (OPTIONAL, "int", "error_no"),
     ]),

--- a/src/firebuild/firebuild.cc
+++ b/src/firebuild/firebuild.cc
@@ -1012,11 +1012,6 @@ void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf,
           reinterpret_cast<const FBBCOMM_Serialized_rename *>(fbbcomm_buf));
       break;
     }
-    case FBBCOMM_TAG_symlink: {
-      ::firebuild::ProcessFBBAdaptor::handle(proc,
-          reinterpret_cast<const FBBCOMM_Serialized_symlink *>(fbbcomm_buf));
-      break;
-    }
     case FBBCOMM_TAG_fcntl: {
       ::firebuild::ProcessFBBAdaptor::handle(proc,
           reinterpret_cast<const FBBCOMM_Serialized_fcntl *>(fbbcomm_buf));
@@ -1049,6 +1044,14 @@ void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf,
     }
     case FBBCOMM_TAG_link: {
       proc->exec_point()->disable_shortcutting_bubble_up("Creating a hard link is not supported");
+      break;
+    }
+    case FBBCOMM_TAG_symlink: {
+      proc->exec_point()->disable_shortcutting_bubble_up("Creating a symlink is not supported");
+      break;
+    }
+    case FBBCOMM_TAG_readlink: {
+      proc->exec_point()->disable_shortcutting_bubble_up("Calling readlink() is not supported");
       break;
     }
     case FBBCOMM_TAG_fstat: {
@@ -1116,7 +1119,6 @@ void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf,
     case FBBCOMM_TAG_gethostname:
     case FBBCOMM_TAG_lockf:
     case FBBCOMM_TAG_pathconf:
-    case FBBCOMM_TAG_readlink:
     case FBBCOMM_TAG_scproc_resp:
     case FBBCOMM_TAG_syscall:
     case FBBCOMM_TAG_sysconf:

--- a/src/firebuild/process.h
+++ b/src/firebuild/process.h
@@ -371,18 +371,6 @@ class Process {
                     const int error = 0);
 
   /**
-   * Handle symlink()
-   * @param old_ar_name old relative or absolute file name
-   * @param newdirfd the newdirfd of symlinkat(), or AT_FDCWD
-   * @param new_ar_name new relative or absolute file name
-   * @param error error code
-   * @return 0 on success, -1 on failure
-   */
-  int handle_symlink(const char * const old_ar_name,
-                     const int newdirfd, const char * const new_ar_name,
-                     const int error = 0);
-
-  /**
    * Handle successfully clearing the cloexec bit, via a
    * posix_spawn_file_actions_adddup2() handler with oldfd==newfd.
    * @param fd file descriptor

--- a/src/firebuild/process_fbb_adaptor.cc
+++ b/src/firebuild/process_fbb_adaptor.cc
@@ -134,13 +134,6 @@ int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_rename *ms
                              fbbcomm_serialized_rename_get_newpath_len(msg), error);
 }
 
-int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_symlink *msg) {
-  const int newdirfd = fbbcomm_serialized_symlink_get_newdirfd_with_fallback(msg, AT_FDCWD);
-  const int error = fbbcomm_serialized_symlink_get_error_no_with_fallback(msg, 0);
-  return proc->handle_symlink(fbbcomm_serialized_symlink_get_oldpath(msg), newdirfd,
-                              fbbcomm_serialized_symlink_get_newpath(msg), error);
-}
-
 int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_fcntl *msg) {
   const int error = fbbcomm_serialized_fcntl_get_error_no_with_fallback(msg, 0);
   int arg = fbbcomm_serialized_fcntl_get_arg_with_fallback(msg, 0);

--- a/src/firebuild/process_fbb_adaptor.h
+++ b/src/firebuild/process_fbb_adaptor.h
@@ -34,7 +34,6 @@ class ProcessFBBAdaptor {
   static int handle(Process *proc, const FBBCOMM_Serialized_dup *msg);
   static int handle(Process *proc, const FBBCOMM_Serialized_dup3 *msg);
   static int handle(Process *proc, const FBBCOMM_Serialized_rename *msg);
-  static int handle(Process *proc, const FBBCOMM_Serialized_symlink *msg);
   static int handle(Process *proc, const FBBCOMM_Serialized_fcntl *msg);
   static int handle(Process *proc, const FBBCOMM_Serialized_ioctl *msg);
   static int handle(Process *proc, const FBBCOMM_Serialized_read_from_inherited *msg);


### PR DESCRIPTION
We don't support explicit symlink operations yet. Disable shortcutting
on a symlink() attempt, readlink(), as well as lstat() if the result is
a symlink or an error.

Fixes #784.