### PR TITLE
supervisor: Refactor file usage handling and updating

### DIFF
--- a/src/firebuild/CMakeLists.txt
+++ b/src/firebuild/CMakeLists.txt
@@ -63,7 +63,9 @@ add_executable(firebuild-bin
   hash_cache.cc
   file.cc
   file_fd.cc
+  file_info.cc
   file_usage.cc
+  file_usage_update.cc
   blob_cache.cc
   obj_cache.cc
   utils.cc

--- a/src/firebuild/execed_process.h
+++ b/src/firebuild/execed_process.h
@@ -14,8 +14,10 @@
 #include <string>
 #include <vector>
 
+#include "firebuild/file_info.h"
 #include "firebuild/file_name.h"
 #include "firebuild/file_usage.h"
+#include "firebuild/file_usage_update.h"
 #include "firebuild/pipe.h"
 #include "firebuild/pipe_recorder.h"
 #include "firebuild/process.h"
@@ -95,12 +97,8 @@ class ExecedProcess : public Process {
                    const int64_t stime_u);
 
   void initialize();
-  void propagate_file_usage(const FileName *name,
-                            const FileUsage* fu_change);
-  bool register_file_usage(const FileName *name, const FileName *actual_file,
-                           FileAction action, int flags, int error);
-  bool register_file_usage(const FileName *name, const FileUsage* fu_change);
-  bool register_parent_directory(const FileName *name, FileInitialState initial_state = ISDIR);
+  bool register_file_usage_update(const FileName *name, const FileUsageUpdate& update);
+  bool register_parent_directory(const FileName *name, FileType type = ISDIR);
   void add_pipe(std::shared_ptr<Pipe> pipe) {created_pipes_.insert(pipe);}
   std::vector<inherited_outgoing_pipe_t>& inherited_outgoing_pipes()
       {return inherited_outgoing_pipes_;}

--- a/src/firebuild/file_info.cc
+++ b/src/firebuild/file_info.cc
@@ -1,0 +1,63 @@
+/* Copyright (c) 2022 Interri Kft. */
+/* This file is an unpublished work. All rights reserved. */
+
+/**
+ * FileInfo describes the (potentially partial) information that we know about a certain file, as it
+ * looked like / looks like / will look like in a certain point in time. It's up to the user of this
+ * structure to decide which point in time they refer to.
+ */
+
+#include "firebuild/file_info.h"
+
+#include "common/firebuild_common.h"
+#include "firebuild/debug.h"
+#include "firebuild/hash.h"
+#include "firebuild/hash_cache.h"
+
+namespace firebuild {
+
+bool operator==(const FileInfo& lhs, const FileInfo& rhs) {
+  return lhs.type_ == rhs.type_ &&
+         lhs.hash_known_ == rhs.hash_known_ &&
+         lhs.hash_ == rhs.hash_;
+}
+
+/* Global debugging methods.
+ * level is the nesting level of objects calling each other's d(), bigger means less info to print.
+ * See #431 for design and rationale. */
+std::string d(const FileInfo& fi, const int level) {
+  (void)level;  /* unused */
+  return std::string("{FileInfo type=") +
+      file_type_to_string(fi.type()) +
+      (fi.hash_known() ?
+          ", hash=" + d(fi.hash()) : "") + "}";
+}
+std::string d(const FileInfo *fi, const int level) {
+  if (fi) {
+    return d(*fi, level);
+  } else {
+    return "{FileInfo NULL}";
+  }
+}
+
+const char *file_type_to_string(FileType type) {
+  switch (type) {
+    case DONTKNOW:
+      return "dontknow";
+    case NOTEXIST:
+      return "notexist";
+    case NOTEXIST_OR_ISREG_EMPTY:
+      return "notexist_or_isreg_empty";
+    case NOTEXIST_OR_ISREG:
+      return "notexist_or_isreg";
+    case ISREG:
+      return "isreg";
+    case ISDIR:
+      return "isdir";
+    default:
+      assert(0 && "unknown type");
+      return "UNKNOWN";
+  }
+}
+
+}  /* namespace firebuild */

--- a/src/firebuild/file_info.h
+++ b/src/firebuild/file_info.h
@@ -1,0 +1,124 @@
+/* Copyright (c) 2022 Interri Kft. */
+/* This file is an unpublished work. All rights reserved. */
+
+#ifndef FIREBUILD_FILE_INFO_H_
+#define FIREBUILD_FILE_INFO_H_
+
+#include <string>
+
+#include "firebuild/hash.h"
+
+namespace firebuild {
+
+typedef enum {
+  /** We don't have any information about this file yet (used only temporarily
+   *  while building up our data structures). */
+  DONTKNOW,
+  /** We know and care that the file or directory did not exist before (e.g. an
+   *  open(O_CREAT|O_WRONLY|O_EXCL) or a mkdir() succeeded). */
+  NOTEXIST,
+  /** We know and care that the file either did not exist before, or was
+   *  a zero sized regular file (but we do not know which of these, because
+   *  an open(O_CREAT|O_WRONLY) succeeded and resulted in a zero length file). */
+  NOTEXIST_OR_ISREG_EMPTY,
+  /** We know and care that the file either did not exist before, or was a
+   *  regular file (e.g. a creat() a.k.a. open(O_CREAT|O_WRONLY|O_TRUNC) succeeded). */
+  NOTEXIST_OR_ISREG,
+  /** We know and care that the regular file existed before.
+   *  (Maybe we don't know more, e.g. an open(O_WRONLY|O_TRUNC) succeeded.
+   *  Maybe we know the size, e.g. a stat() succeeded.
+   *  Maybe we know the size and the checksum, e.g. an open() succeeded for reading,
+   *  or for writing without truncating.) */
+  ISREG,
+  /** We know and care that the directory existed before.
+   *  (Maybe we don't know more, e.g. a stat() succeeded.
+   *  Maybe we know the listing's checksum, e.g. an opendir() was performed.) */
+  ISDIR,
+  FILE_TYPE_MAX = ISDIR
+} FileType;
+
+class FileInfo {
+ public:
+  explicit FileInfo(FileType type = DONTKNOW, const Hash *hash = nullptr) :
+      type_(type),
+      hash_known_(hash != nullptr),
+      hash_(hash != nullptr ? *hash : Hash()) {
+    assert(type == ISREG || type == ISDIR || hash == nullptr);
+  }
+
+  FileType type() const {return type_;}
+  void set_type(FileType type) {type_ = type;}
+  bool hash_known() const {return hash_known_;}
+  const Hash& hash() const {return hash_;}
+  void set_hash(const Hash& hash) {
+    hash_ = hash;
+    hash_known_ = true;
+  }
+
+  /* Misc */
+  static int file_type_to_int(const FileType t) {
+    switch (t) {
+      case DONTKNOW: return DONTKNOW;
+      case NOTEXIST: return NOTEXIST;
+      case NOTEXIST_OR_ISREG_EMPTY: return NOTEXIST_OR_ISREG_EMPTY;
+      case NOTEXIST_OR_ISREG: return NOTEXIST_OR_ISREG;
+      case ISREG: return ISREG;
+      case ISDIR: return ISDIR;
+      default:
+        abort();
+    }
+  }
+
+  static FileType int_to_file_type(const int t) {
+    switch (t) {
+      case DONTKNOW: return DONTKNOW;
+      case NOTEXIST: return NOTEXIST;
+      case NOTEXIST_OR_ISREG_EMPTY: return NOTEXIST_OR_ISREG_EMPTY;
+      case NOTEXIST_OR_ISREG: return NOTEXIST_OR_ISREG;
+      case ISREG: return ISREG;
+      case ISDIR: return ISDIR;
+      default:
+        abort();
+    }
+  }
+
+ private:
+  /** File type. */
+  FileType type_;
+
+  /** Whether the checksum is known. Only if type_ is ISREG or ISDIR. */
+  bool hash_known_ : 1;
+
+  /** The checksum, if known. Only if type_ is ISREG or ISDIR.
+   *  For directories, it's the checksum of its listing. */
+  Hash hash_;
+
+  // TODO(rbalint) make user of stat results, but store them in a more compressed
+  /** If the file was stat()'ed during the process's lifetime, that is,
+   *  its initial metadata might be relevant. */
+  // bool stated_ : 1;
+
+  // form instead of in the huge struct stat64
+  /** The error from initially stat()'ing the file, or 0 if there was no
+   *  error. */
+  // int initial_stat_err_;
+
+  /** The result of initially stat()'ing the file. Only valid if stated_
+   *  && !initial_stat_err_. */
+  // struct stat64 initial_stat_;
+
+  friend bool operator==(const FileInfo& lhs, const FileInfo& rhs);
+};
+
+bool operator==(const FileInfo& lhs, const FileInfo& rhs);
+
+/* Global debugging methods.
+ * level is the nesting level of objects calling each other's d(), bigger means less info to print.
+ * See #431 for design and rationale. */
+std::string d(const FileInfo& fi, const int level = 0);
+std::string d(const FileInfo *fi, const int level = 0);
+const char *file_type_to_string(FileType type);
+
+}  /* namespace firebuild */
+
+#endif  // FIREBUILD_FILE_INFO_H_

--- a/src/firebuild/file_usage.cc
+++ b/src/firebuild/file_usage.cc
@@ -10,34 +10,36 @@
  * hash is computed and stored here, but if the Process does not read
  * the contents then it is not stored. Similarly, it's recorded whether
  * the process potentially modified the file.
+ *
+ * All these objects are kept in a global pool. If two such objects have
+ * identical contents then they are the same object (same pointer).
  */
 
 #include "firebuild/file_usage.h"
 
 #include <sys/stat.h>
 
+#include <string>
 #include <unordered_set>
 
 #include "common/firebuild_common.h"
 #include "firebuild/debug.h"
 #include "firebuild/hash.h"
-#include "firebuild/hash_cache.h"
 
 namespace firebuild {
 
 std::unordered_set<FileUsage, FileUsageHasher>* FileUsage::db_;
-const FileUsage* FileUsage::no_hash_not_written_states_[INITIAL_STATE_MAX + 1];
-const FileUsage* FileUsage::no_hash_written_states_[INITIAL_STATE_MAX + 1];
-
+const FileUsage* FileUsage::no_hash_not_written_states_[FILE_TYPE_MAX + 1];
+const FileUsage* FileUsage::no_hash_written_states_[FILE_TYPE_MAX + 1];
 
 FileUsage::DbInitializer::DbInitializer() {
   db_ = new std::unordered_set<FileUsage, FileUsageHasher>();
-  for (int i = 0; i <= INITIAL_STATE_MAX; i++) {
-    const FileUsage fu(int_to_initial_state(i), Hash());
+  for (int i = 0; i <= FILE_TYPE_MAX; i++) {
+    const FileUsage fu(FileInfo::int_to_file_type(i));
     no_hash_not_written_states_[i] = &*db_->insert(fu).first;
   }
-  for (int i = 0; i <= INITIAL_STATE_MAX; i++) {
-    const FileUsage fu(int_to_initial_state(i), Hash(), true);
+  for (int i = 0; i <= FILE_TYPE_MAX; i++) {
+    const FileUsage fu(FileInfo::int_to_file_type(i), true);
     no_hash_written_states_[i] = &*db_->insert(fu).first;
   }
 }
@@ -45,15 +47,11 @@ FileUsage::DbInitializer::DbInitializer() {
 FileUsage::DbInitializer FileUsage::db_initializer_;
 
 bool operator==(const FileUsage& lhs, const FileUsage& rhs) {
-  return (lhs.initial_state_ == rhs.initial_state_
-          && lhs.initial_hash_ == rhs.initial_hash_
-          // && lhs.stated_ == rhs.stated_
-          // TODO(rbalint) no operator==()
-          // && lhs.initial_stat_ == rhs.initial_stat_
-          && lhs.written_ == rhs.written_
-          // && lhs.stat_changed_ == rhs.stat_changed_
-          && lhs.unknown_err_ == rhs.unknown_err_);
-          }
+  return lhs.initial_state_ == rhs.initial_state_ &&
+         lhs.written_ == rhs.written_ &&
+         // lhs.stat_changed_ == rhs.stat_changed_ &&
+         lhs.unknown_err_ == rhs.unknown_err_;
+}
 
 const FileUsage* FileUsage::Get(const FileUsage& candidate) {
   auto it = db_->find(candidate);
@@ -66,286 +64,141 @@ const FileUsage* FileUsage::Get(const FileUsage& candidate) {
 }
 
 /**
- * Merge the other FileUsage object into this one.
+ * Merge a FileUsageUpdate object into this one.
  *
- * "this" describes the older event(s) which happened to a file, and
- * "that" describes the new one. Sometimes the file usages to merge are conflicting, like
- * a directory was expected to not exist, then it is expected to exist without creating it in
- * the meantime. In those cases the return is nullptr and it should disable shortcutting of the
- * process and its ancestors.
- * @return pointer to the merge result, it may be different from either "this" and "that" and
- *        can be nullptr
+ * "this" describes the older events which happened to a file, and "update" describes the new ones.
+ *
+ * "this" is not updated, a possibly different pointer is returned which refers to the merged value.
+ *
+ * "update" might on demand compute certain values (currently the hash). It's formally "const", but
+ * with some "mutable" members. The value behind the "update" reference is updated, so when this
+ * change is bubbled up, at the next levels it'll have this field already filled in.
+ *
+ * Sometimes the file usages to merge are conflicting, like a directory was expected to not exist,
+ * then it is expected to exist without creating it in the meantime. In those cases the return is
+ * nullptr and it should disable shortcutting of the process and its ancestors.
+ *
+ * @return pointer to the merge result, or nullptr in case of an error
  */
-const FileUsage* FileUsage::merge(const FileUsage* that) const {
-  TRACKX(FB_DEBUG_PROC, 1, 1, FileUsage, this, "other=%s", D(that));
-
-  if (*this == *that) {
-    return this;
-  }
+const FileUsage *FileUsage::merge(const FileUsageUpdate& update) const {
+  TRACKX(FB_DEBUG_PROC, 1, 1, FileUsage, this, "other=%s", D(update));
 
   FileUsage tmp = *this;
 
   bool changed = false;
-  switch (initial_state_) {
-    case DONTKNOW: {
-      if (initial_state_ != that->initial_state_) {
-        tmp.initial_state_ = that->initial_state_;
-        changed = true;
-      }
-      if (that->initial_hash_known_ && initial_hash_ != that->initial_hash_) {
-        tmp.initial_hash_ = that->initial_hash_;
-        tmp.initial_hash_known_ = true;
-        changed = true;
-      }
-      break;
-    }
-    case NOTEXIST:
-    case NOTEXIST_OR_ISREG:
-    case NOTEXIST_OR_ISREG_EMPTY: {
-      if (!written_ && !that->written_ && that->initial_state_ == ISDIR) {
-        return nullptr;
-      }
-      break;
-    }
-    case ISREG: {
-      if (!written_ && !that->written_ && !initial_hash_known_ && that->initial_hash_known_) {
-        tmp.initial_hash_ = that->initial_hash_;
-        tmp.initial_hash_known_ = true;
-        changed = true;
-      }
-      break;
-    }
-    case ISDIR: {
-      if (!written_ && !that->written_ && !initial_hash_known_ && that->initial_hash_known_) {
-        tmp.initial_hash_ = that->initial_hash_;
-        tmp.initial_hash_known_ = true;
-        changed = true;
-      }
-      break;
-    }
-  }
 
-  if (!written_ && that->written_) {
-    changed = true;
+  if (!written_) {
+    /* Note: this might lazily query the type now. Avoid calling it multiple times. */
+    FileType update_initial_type;
+    if (!update.get_initial_type(&update_initial_type)) {
+      return nullptr;
+    }
+
+    switch (initial_type()) {
+      case DONTKNOW: {
+        if (initial_type() != update_initial_type) {
+          tmp.set_initial_type(update_initial_type);
+          changed = true;
+        }
+        if (!initial_hash_known() && update.initial_hash_known()) {
+          Hash hash;
+          /* Note: this might lazily compute the hash now. */
+          if (!update.get_initial_hash(&hash)) {
+            return nullptr;
+          }
+          tmp.set_initial_hash(hash);
+          changed = true;
+        }
+        break;
+      }
+      case NOTEXIST: {
+        if (update_initial_type != DONTKNOW &&
+            update_initial_type != NOTEXIST &&
+            update_initial_type != NOTEXIST_OR_ISREG &&
+            update_initial_type != NOTEXIST_OR_ISREG_EMPTY) {
+          return nullptr;
+        }
+        break;
+      }
+      case ISREG: {
+        if (update_initial_type != DONTKNOW &&
+            update_initial_type != NOTEXIST_OR_ISREG &&
+            update_initial_type != NOTEXIST_OR_ISREG_EMPTY &&
+            update_initial_type != ISREG) {
+          return nullptr;
+        }
+        if (!initial_hash_known() && update.initial_hash_known()) {
+          Hash hash;
+          /* Note: this might lazily compute the hash now. */
+          if (!update.get_initial_hash(&hash)) {
+            return nullptr;
+          }
+          tmp.set_initial_hash(hash);
+          changed = true;
+        }
+        break;
+      }
+      case ISDIR: {
+        if (update_initial_type != DONTKNOW &&
+            update_initial_type != ISDIR) {
+          return nullptr;
+        }
+        if (!initial_hash_known() && update.initial_hash_known()) {
+          Hash hash;
+          /* Note: this might lazily compute the hash now. */
+          if (!update.get_initial_hash(&hash)) {
+            return nullptr;
+          }
+          tmp.set_initial_hash(hash);
+          changed = true;
+        }
+        break;
+      }
+      case NOTEXIST_OR_ISREG:
+      case NOTEXIST_OR_ISREG_EMPTY: {
+        /* These imply the written_ bit, so cannot happen here. */
+        assert(0);
+        break;
+      }
+    }
+
+    if (update.written()) {
+      tmp.written_ = true;
+      changed = true;
+    }
   }
-  tmp.written_ = written_ || that->written_;
 
   if (!changed) {
     return this;
   } else {
-    if (tmp == *that) {
-      return that;
-    } else {
-      return FileUsage::Get(tmp);
-    }
+    return FileUsage::Get(tmp);
   }
-}
-
-/**
- * Based on the parameters and return value of an open() or similar
- * call, updates the current FileUsage object to reflect the known
- * initial state of the file.
- *
- * If do_read is false, it's assumed that the file was already opened
- * (or at least attempted to) for reading, and as such the initial
- * values are not changed; only the written property is updated.
- */
-bool FileUsage::update_from_open_params(const FileName* filename,
-                                        FileAction action, int flags, int err,
-                                        bool do_read, bool* hash_changed) {
-  TRACKX(FB_DEBUG_PROC, 1, 1, FileUsage, this,
-         "filename=%s, action=%s, flags=%d, err=%d, do_read=%s",
-         D(filename), file_action_to_string(action), flags, err, D(do_read));
-
-  if (!do_read) {
-    if (is_write(flags) && !err) {
-      written_ = true;
-    }
-    return true;
-  }
-
-  if (!err) {
-    if (action == FILE_ACTION_OPEN) {
-      if (is_write(flags)) {
-        /* If successfully opened for writing:
-         *
-         *     trunc   creat   excl
-         * A     +       -            => prev file must exist, contents don't matter
-         * B     +       +       -    => prev file doesn't matter
-         * C     +       +       +    => prev file mustn't exist
-         * D     -       -            => prev file must exist, contents preserved and matter
-         * E     -       +       -    => contents preserved (or new empty) and matter
-         * F     -       +       +    => prev file mustn't exist
-         */
-        if ((flags & O_CREAT) && (flags & O_EXCL)) {
-          /* C+F: If an exclusive new file was created, take a note that
-           * the file didn't exist previously. */
-          initial_state_ = NOTEXIST;
-        } else if (flags & O_TRUNC) {
-          if (!(flags & O_CREAT)) {
-            /* A: What a nasty combo! We must take a note that the file
-             * existed, but don't care about its previous contents (also
-             * it's too late now to figure that out). */
-            initial_state_ = ISREG;
-          } else {
-            /* B: The old contents could have been any regular file, or
-             * even no such file (but not e.g. a directory). */
-            initial_state_ = NOTEXIST_OR_ISREG;
-          }
-        } else {
-          if (!(flags & O_CREAT)) {
-            /* D: Contents unchanged. Need to checksum the file. */
-            if (!hash_cache->get_hash(filename, &initial_hash_)) {
-              unknown_err_ = errno;
-              return false;
-            }
-            initial_hash_known_ = true;
-            initial_state_ = ISREG;
-            *hash_changed  = true;
-          } else {
-            /* E: Another nasty combo. We can't distinguish a newly
-             * created empty file from a previously empty one. If the file
-             * is non-empty, we need to store its hash. */
-            struct stat st;
-            if (stat(filename->c_str(), &st) == -1) {
-              unknown_err_ = errno;
-              return false;
-            }
-            if (st.st_size > 0) {
-              if (!hash_cache->get_hash(filename, &initial_hash_)) {
-                unknown_err_ = errno;
-                return false;
-              }
-              initial_hash_known_ = true;
-              initial_state_ = ISREG;
-              *hash_changed  = true;
-            } else {
-              initial_state_ = NOTEXIST_OR_ISREG_EMPTY;
-            }
-          }
-        }
-        written_ = true;
-      } else {
-        /* The file or directory was successfully opened for reading only.
-         * Note that a plain open() can open a directory for reading, even without O_DIRECTORY. */
-        bool is_dir;
-        if (!hash_cache->get_hash(filename, &initial_hash_, &is_dir)) {
-          unknown_err_ = errno;
-          return false;
-        }
-        initial_hash_known_ = true;
-        initial_state_ = is_dir ? ISDIR : ISREG;
-      }
-    } else if (action == FILE_ACTION_MKDIR) {
-      initial_state_ = NOTEXIST;
-      written_ = true;
-    } else if (action == FILE_ACTION_STATFILE) {
-      /* The file exists. */
-      // TODO(rbalint) handle size info, and possibly other info, too
-      initial_state_ = ISREG;
-    } else if (action == FILE_ACTION_STATDIR) {
-      /* The directory exists. */
-      initial_state_ = ISDIR;
-    }
-  } else /* if (err) */ {
-    if (action == FILE_ACTION_OPEN) {
-      /* The attempt to open failed. */
-      if (is_write(flags)) {
-        /* ENOENT and ENOTDIR are handled in the caller. */
-        assert_cmp(err, !=, ENOENT);
-        assert_cmp(err, !=, ENOTDIR);
-        /* We don't support other errors such as permission denied. */
-        unknown_err_ = err;
-        return false;
-      } else {
-        /* Opening for reading failed. */
-        if (err == ENOENT) {
-          initial_state_ = NOTEXIST;
-        } else {
-          /* ENOTDIR is handled in the caller. */
-          assert_cmp(err, !=, ENOTDIR);
-          /* We don't support other errors such as permission denied. */
-          unknown_err_ = err;
-          return false;
-        }
-      }
-    } else if (action == FILE_ACTION_MKDIR) {
-      if (err == EEXIST) {
-        /* The directory already exists. It may not be a directory, but in that case process inputs
-         * will not match either. */
-        initial_state_ = ISDIR;
-      } else {
-        /* We don't support other errors such as permission denied. */
-        unknown_err_ = err;
-        return false;
-      }
-    } else if (action == FILE_ACTION_STATFILE) {
-      /* The file does not exist. */
-      initial_state_ = NOTEXIST;
-    } else if (action == FILE_ACTION_STATDIR) {
-      assert(0 && "If file does not exist stat() can't tell that it is a directory");
-      initial_state_ = NOTEXIST;
-    }
-  }
-  return true;
 }
 
 bool file_file_usage_cmp(const file_file_usage& lhs, const file_file_usage& rhs) {
   return strcmp(lhs.file->c_str(), rhs.file->c_str()) < 0;
 }
 
+/* Member debugging method. Not to be called directly, call the global d(obj_or_ptr) instead.
+ * level is the nesting level of objects calling each other's d(), bigger means less info to print.
+ * See #431 for design and rationale. */
+std::string FileUsage::d_internal(const int level) const {
+  (void)level;  /* unused */
+  return std::string("{FileUsage initial_state=") + d(initial_state_, level) +
+      ", written=" + d(written_) + "}";
+}
+
 /* Global debugging methods.
  * level is the nesting level of objects calling each other's d(), bigger means less info to print.
  * See #431 for design and rationale. */
 std::string d(const FileUsage& fu, const int level) {
-  (void)level;  /* unused */
-  return std::string("{FileUsage initial_state=") +
-      file_initial_state_to_string(fu.initial_state()) +
-      (fu.initial_hash_known() ?
-          ", hash=" + d(fu.initial_hash()) : "") +
-      ", written=" + d(fu.written()) + "}";
+  return fu.d_internal(level);
 }
 std::string d(const FileUsage *fu, const int level) {
   if (fu) {
     return d(*fu, level);
   } else {
     return "{FileUsage NULL}";
-  }
-}
-
-const char *file_initial_state_to_string(FileInitialState state) {
-  switch (state) {
-    case DONTKNOW:
-      return "dontknow";
-    case NOTEXIST:
-      return "notexist";
-    case NOTEXIST_OR_ISREG_EMPTY:
-      return "notexist_or_isreg_empty";
-    case NOTEXIST_OR_ISREG:
-      return "notexist_or_isreg";
-    case ISREG:
-      return "isreg";
-    case ISDIR:
-      return "isdir";
-    default:
-      assert(0 && "unknown state");
-      return "UNKNOWN";
-  }
-}
-
-const char *file_action_to_string(FileAction action) {
-  switch (action) {
-    case FILE_ACTION_OPEN:
-      return "open";
-    case FILE_ACTION_MKDIR:
-      return "mkdir";
-    case FILE_ACTION_STATFILE:
-      return "stat (on file)";
-    case FILE_ACTION_STATDIR:
-      return "stat (on dir)";
-    default:
-      assert(0 && "unknown action");
-      return "UNKNOWN";
   }
 }
 

--- a/src/firebuild/file_usage.h
+++ b/src/firebuild/file_usage.h
@@ -11,122 +11,51 @@
 #include <string>
 #include <unordered_set>
 
+#include "firebuild/file_info.h"
+#include "firebuild/file_usage_update.h"
 #include "firebuild/hash.h"
 #include "firebuild/cxx_lang_utils.h"
 
 namespace firebuild {
 
-typedef enum {
-  /** We don't have any information about this file yet (used only temporarily
-   *  while building up our data structures). */
-  DONTKNOW,
-  /** We know and care that the file or directory did not exist before (e.g. an
-   *  open(O_CREAT|O_WRONLY|O_EXCL) or a mkdir() succeeded). */
-  NOTEXIST,
-  /** We know and care that the file either did not exist before, or was
-   *  a zero sized regular file (but we do not know which of these, because
-   *  an open(O_CREAT|O_WRONLY) succeeded and resulted in a zero length file). */
-  NOTEXIST_OR_ISREG_EMPTY,
-  /** We know and care that the file either did not exist before, or was a
-   *  regular file (e.g. a creat() a.k.a. open(O_CREAT|O_WRONLY|O_TRUNC) succeeded). */
-  NOTEXIST_OR_ISREG,
-  /** We know and care that the regular file existed before.
-   *  (Maybe we don't know more, e.g. an open(O_WRONLY|O_TRUNC) succeeded.
-   *  Maybe we know the size, e.g. a stat() succeeded.
-   *  Maybe we know the size and the checksum, e.g. an open() succeeded for reading,
-   *  or for writing without truncating.) */
-  ISREG,
-  /** We know and care that the directory existed before.
-   *  (Maybe we don't know more, e.g. a stat() succeeded.
-   *  Maybe we know the listing's checksum, e.g. an opendir() was performed.) */
-  ISDIR,
-  INITIAL_STATE_MAX = ISDIR
-} FileInitialState;
-
-typedef enum {
-  /** Performed an open() or creat() on the path */
-  FILE_ACTION_OPEN,
-  /** Performed a mkdir() on the path */
-  FILE_ACTION_MKDIR,
-  /** Performed a stat() on the path and the path which was not a directory */
-  FILE_ACTION_STATFILE,
-  /** Performed a stat() on the path and the path which was a directory */
-  FILE_ACTION_STATDIR,
-} FileAction;
-
 struct FileUsageHasher;
 
 class FileUsage {
  public:
-  FileInitialState initial_state() const {return initial_state_;}
-  bool initial_hash_known() const {return initial_hash_known_;}
-  const Hash& initial_hash() const {return initial_hash_;}
   bool written() const {return written_;}
-
   int unknown_err() {return unknown_err_;}
   void set_unknown_err(int e) {unknown_err_ = e;}
 
-  static const FileUsage* Get(FileInitialState initial_state,
-                              Hash hash, bool written = false) {
-    FileUsage tmp_file_usage(initial_state, hash, written);
-    return (Get(tmp_file_usage));
-  }
-  static const FileUsage* Get(FileInitialState initial_state = DONTKNOW, bool written = false) {
+  FileType initial_type() const {return initial_state_.type();}
+  void set_initial_type(FileType type) {initial_state_.set_type(type);}
+  bool initial_hash_known() const {return initial_state_.hash_known();}
+  const Hash& initial_hash() const {return initial_state_.hash();}
+  void set_initial_hash(const Hash& hash) {initial_state_.set_hash(hash);}
+
+  static const FileUsage* Get(FileType type = DONTKNOW, bool written = false) {
     if (written) {
-      return no_hash_written_states_[initial_state_to_int(initial_state)];
+      return no_hash_written_states_[FileInfo::file_type_to_int(type)];
     } else {
-      return no_hash_not_written_states_[initial_state_to_int(initial_state)];
+      return no_hash_not_written_states_[FileInfo::file_type_to_int(type)];
     }
   }
 
-  static const FileUsage* Get(const FileName* filename, FileAction action,
-                              int flags, int err, bool do_read) {
-    FileUsage tmp_file_usage;
-    bool hash_set = false;
-    if (!tmp_file_usage.update_from_open_params(filename, action, flags, err, do_read, &hash_set)) {
-      return nullptr;
-    } else {
-      return (Get(tmp_file_usage));
-    }
-  }
+  const FileUsage *merge(const FileUsageUpdate& update) const;
 
-  const FileUsage* merge(const FileUsage* that) const;
-  bool open(const FileName* filename, int flags, int err, Hash **hashpp);
-
+  /* Member debugging method. Not to be called directly, call the global d(obj_or_ptr) instead.
+   * level is the nesting level of objects calling each other's d(), bigger means less info to print.
+   * See #431 for design and rationale. */
+  std::string d_internal(const int level = 0) const;
 
  private:
-  FileUsage(FileInitialState initial_state, Hash hash, bool written = false) :
-      /*read_(false),*/
-      initial_hash_(hash),
-      initial_state_(initial_state),
-      initial_hash_known_(false),
-      // TODO(rbalint) use that later
-      // stated_(false),
-      written_(written),
-      // TODO(rbalint) use those later
-      // stat_changed_(true),
-      // initial_stat_err_(0),
-      // initial_stat_(),
-      unknown_err_(0) {}
-  explicit FileUsage(FileInitialState initial_state = DONTKNOW) :
-      FileUsage(initial_state, Hash()) {}
+  explicit FileUsage(FileType type = DONTKNOW, bool written = false) :
+      initial_state_(type), written_(written), unknown_err_(0) {}
+
+  FileUsage(const FileInfo *initial_state, bool written, int unknown_err):
+      initial_state_(*initial_state), written_(written), unknown_err_(unknown_err) {}
 
   /* Things that describe the filesystem when the process started up */
-
-  /** The initial checksum, if known. Only if initial_state_ is ISREG or ISDIR.
-   *  For directories, it's the checksum of its listing. */
-  Hash initial_hash_;
-
-  /** The file's contents at the process's startup. More precisely, at
-   *  the time the process first tries to do anything with this file
-   *  that could be relevant, because at process startup we have no idea
-   *  which files we'll need to monitor. See the comment of the
-   *  individual enum numbers for more details. */
-  FileInitialState initial_state_ : 3;
-
-  /** Whether the initial checksum of the file or directory is known.
-   *  Only if initial_state_ is ISREG or ISDIR. */
-  bool initial_hash_known_ : 1;
+  FileInfo initial_state_;
 
   /* Things that describe what the process potentially did */
 
@@ -135,24 +64,10 @@ class FileUsage {
    *  another file getting renamed to this one. */
   bool written_ : 1;
 
-  // TODO(rbalint) make user of stat results, but store them in a more compressed
-  /** If the file was stat()'ed during the process's lifetime, that is,
-   *  its initial metadata might be relevant. */
-  // bool stated_ : 1;
-
   /** If the file's metadata (e.g. mode) was potentially altered, that is,
    *  the final state is to be remembered.
    *  FIXME Do we need this? We should just always stat() at the end. */
   // bool stat_changed_ : 1;
-
-  // form instead of in the huge struct stat64
-  /** The error from initially stat()'ing the file, or 0 if there was no
-   *  error. */
-  // int initial_stat_err_;
-
-  /** The result of initially stat()'ing the file. Only valid if stated_
-   *  && !initial_stat_err_. */
-  // struct stat64 initial_stat_;
 
   /* Note: stuff like the final hash are not stored here. They are
    * computed right before being placed in the cache, don't need to be
@@ -161,8 +76,8 @@ class FileUsage {
   /** Global FileUsage db*/
   static std::unordered_set<FileUsage, FileUsageHasher>* db_;
   /** Frequently used singletons */
-  static const FileUsage* no_hash_not_written_states_[INITIAL_STATE_MAX + 1];
-  static const FileUsage* no_hash_written_states_[INITIAL_STATE_MAX + 1];
+  static const FileUsage* no_hash_not_written_states_[FILE_TYPE_MAX + 1];
+  static const FileUsage* no_hash_written_states_[FILE_TYPE_MAX + 1];
 
   /* This, along with the FileUsage::db_initializer_ definition in file_usage.cc,
    * initializes the file usage database once at startup. */
@@ -175,48 +90,20 @@ class FileUsage {
   friend struct FileUsageHasher;
   friend bool operator==(const FileUsage& lhs, const FileUsage& rhs);
 
-  /* Misc */
-  static int initial_state_to_int(const FileInitialState s) {
-    switch (s) {
-      case DONTKNOW: return DONTKNOW;
-      case NOTEXIST: return NOTEXIST;
-      case NOTEXIST_OR_ISREG_EMPTY: return NOTEXIST_OR_ISREG_EMPTY;
-      case NOTEXIST_OR_ISREG: return NOTEXIST_OR_ISREG;
-      case ISREG: return ISREG;
-      case ISDIR: return ISDIR;
-      default:
-        abort();
-    }
-  }
-
-  static FileInitialState int_to_initial_state(const int s) {
-    switch (s) {
-      case DONTKNOW: return DONTKNOW;
-      case NOTEXIST: return NOTEXIST;
-      case NOTEXIST_OR_ISREG_EMPTY: return NOTEXIST_OR_ISREG_EMPTY;
-      case NOTEXIST_OR_ISREG: return NOTEXIST_OR_ISREG;
-      case ISREG: return ISREG;
-      case ISDIR: return ISDIR;
-      default:
-        abort();
-    }
-  }
-
   /** An unhandled error occurred during operation on the file. The process
    *  can't be short-cut, but the first such error code is stored here. */
   int unknown_err_;
+
   static const FileUsage* Get(const FileUsage& candidate);
-  bool update_from_open_params(const FileName* filename, FileAction action, int flags, int err,
-                               bool do_read, bool* hash_changed);
 };
 
 bool operator==(const FileUsage& lhs, const FileUsage& rhs);
 
 struct FileUsageHasher {
   std::size_t operator()(const FileUsage& f) const noexcept {
-    XXH64_hash_t hash = XXH3_64bits_withSeed(f.initial_hash_.get_ptr(), Hash::hash_size(),
+    XXH64_hash_t hash = XXH3_64bits_withSeed(f.initial_hash().get_ptr(), Hash::hash_size(),
                                              f.unknown_err_);
-    unsigned char merged_state = f.initial_state_;
+    unsigned char merged_state = f.initial_type();
     merged_state |= f.written_ << 6;
     // TODO(rbalint) use those later
     // merged_state |= f.stated_ << 5;
@@ -239,7 +126,6 @@ bool file_file_usage_cmp(const file_file_usage& lhs, const file_file_usage& rhs)
  * See #431 for design and rationale. */
 std::string d(const FileUsage& fu, const int level = 0);
 std::string d(const FileUsage *fu, const int level = 0);
-const char *file_initial_state_to_string(FileInitialState state);
-const char *file_action_to_string(FileAction action);
+
 }  /* namespace firebuild */
 #endif  // FIREBUILD_FILE_USAGE_H_

--- a/src/firebuild/file_usage_update.cc
+++ b/src/firebuild/file_usage_update.cc
@@ -1,0 +1,317 @@
+/* Copyright (c) 2022 Interri Kft. */
+/* This file is an unpublished work. All rights reserved. */
+
+/**
+ * FileUsageUpdate describes, for one particular Process and one particular filename, some pieces of
+ * information that we get to know right now.
+ *
+ * Such structures are not stored in our long-term memory, these are ephemeral objects describing a
+ * change that we quickly register.
+ *
+ * The differences from FileUsage are:
+ *
+ * - A FileUsageUpdate object exists on its own, rather than in a pool of unique objects.
+ *
+ * - A FileUsageUpdate object can describe that some information (e.g. type or hash) matters to us,
+ *   but we haven't queried or computed it yet. This allows for lazy on-demand computation, and
+ *   therefore save precious CPU time if the information isn't needed.
+ *
+ * - A FileUsageUpdate knows which file it belongs to, so it can perform the on-demand work on its own.
+ *
+ * - A FileUsageUpdate carries information about what to do with its parent directory, e.g. whether it
+ *   needs to be registered that it must or must not exist.
+ */
+
+#include "firebuild/file_usage_update.h"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <string>
+
+#include "common/firebuild_common.h"
+#include "firebuild/debug.h"
+#include "firebuild/hash_cache.h"
+
+namespace firebuild {
+
+/**
+ * If we saw a successful open(..., O_RDONLY) then this method initializes the file type (regular
+ * vs. directory) and the hash lazily on demand.
+ */
+void FileUsageUpdate::type_computer_open_rdonly() const {
+  Hash hash;
+  bool is_dir;
+  if (!hash_cache->get_hash(filename_, &hash, &is_dir)) {
+    unknown_err_ = errno;
+    return;
+  }
+  initial_state_.set_type(is_dir ? ISDIR : ISREG);
+  initial_state_.set_hash(hash);
+  type_computer_ = nullptr;
+  hash_computer_ = nullptr;
+}
+
+/**
+ * If we saw a successful open(..., O_WRONLY|O_CREAT) (without O_TRUNC and O_EXCL; perhaps with
+ * O_RDWR instead of O_RDONLY) then the following two cases can happen:
+ * - Now the file is empty. We cannot tell if the file existed and was empty before, or did not exist.
+ * - Now the file is non-empty. We know that the file existed before with the current contents.
+ * This method performs the lazy on-demand check to see which of these two happened.
+ */
+void FileUsageUpdate::type_computer_open_wronly_creat_notrunc_noexcl() const {
+  struct stat st;
+  if (stat(filename_->c_str(), &st) == -1) {
+    unknown_err_ = errno;
+    return;
+  }
+  if (st.st_size > 0) {
+    // FIXME handle if we see a directory. This cannot normally happen due to O_CREAT, but can if
+    // the file has just been replaced by a directory.
+    initial_state_.set_type(ISREG);
+    /* We got to know that this was a regular non-empty file. Delay hash computation until
+     * necessary. */
+    hash_computer_ = &FileUsageUpdate::hash_computer;
+  } else {
+    initial_state_.set_type(NOTEXIST_OR_ISREG_EMPTY);
+  }
+  type_computer_ = nullptr;
+}
+
+/**
+ * Get the file type, looking it up on demand if necessary.
+ *
+ * Due to the nature of lazy lookup, an unexpected error can occur, in which case false is returned.
+ */
+bool FileUsageUpdate::get_initial_type(FileType *type_ptr) const {
+  TRACKX(FB_DEBUG_PROC, 1, 1, FileUsageUpdate, this, "");
+
+  if (type_computer_) {
+    (this->*type_computer_)();
+  }
+  if (unknown_err_) {
+    return false;
+  } else {
+    *type_ptr = initial_state_.type();
+    return true;
+  }
+}
+
+/**
+ * This method executes the lazy on-demand retrieval or computation of the hash.
+ */
+void FileUsageUpdate::hash_computer() const {
+  Hash hash;
+  if (hash_cache->get_hash(filename_, &hash)) {
+    initial_state_.set_hash(hash);
+  } else {
+    unknown_err_ = errno;
+  }
+  hash_computer_ = nullptr;
+}
+
+/**
+ * Get the file hash, figuring it out on demand if necessary.
+ *
+ * Due to the nature of lazy lookup, an unexpected error can occur, in which case false is returned.
+ */
+bool FileUsageUpdate::get_initial_hash(Hash *hash_ptr) const {
+  TRACKX(FB_DEBUG_PROC, 1, 1, FileUsageUpdate, this, "");
+
+  assert(type_computer_ == nullptr &&
+         (initial_state_.type() == ISREG || initial_state_.type() == ISDIR));
+
+  if (hash_computer_) {
+    (this->*hash_computer_)();
+  }
+  if (unknown_err_) {
+    return false;
+  } else {
+    *hash_ptr = initial_state_.hash();
+    return true;
+  }
+}
+
+/**
+ * Based on the parameters and return value of an open() or similar call, returns a FileUsageUpdate
+ * object that reflects how our usage of this file changed.
+ *
+ * If the file's hash is important then we don't compute it yet but set hash_computer_ so that we
+ * can compute it on demand.
+ */
+FileUsageUpdate FileUsageUpdate::get_from_open_params(const FileName *filename, int flags,
+                                                      int err) {
+  TRACK(FB_DEBUG_PROC, "flags=%d, err=%d", flags, err);
+
+  FileUsageUpdate update(filename);
+
+  if (!err) {
+    if (is_write(flags)) {
+      /* If successfully opened for writing:
+       *
+       *     trunc   creat   excl
+       * A     +       -            => prev file must exist, contents don't matter
+       * B     +       +       -    => prev file doesn't matter
+       * C     +       +       +    => prev file mustn't exist
+       * D     -       -            => prev file must exist, contents preserved and matter
+       * E     -       +       -    => contents preserved (or new empty) and matter
+       * F     -       +       +    => prev file mustn't exist
+       */
+      if ((flags & O_CREAT) && (flags & O_EXCL)) {
+        /* C+F: If an exclusive new file was created, take a note that the file didn't exist
+         * previously, but its parent dir has to exist. */
+        update.set_initial_type(NOTEXIST);
+        update.parent_type_ = ISDIR;
+      } else if (flags & O_TRUNC) {
+        if (!(flags & O_CREAT)) {
+          /* A: What a nasty combo! We must take a note that the file existed, but don't care about
+           * its previous contents (also it's too late now to figure that out). This implies that
+           * the parent directory exists, no need to note that separately. */
+          update.set_initial_type(ISREG);
+        } else {
+          /* B: The old contents could have been any regular file, or even no such file (but not
+           * e.g. a directory). Also, the parent directory has to exist. */
+          update.set_initial_type(NOTEXIST_OR_ISREG);
+          update.parent_type_ = ISDIR;
+        }
+      } else {
+        if (!(flags & O_CREAT)) {
+          /* D: Contents unchanged. Need to checksum the file, we'll do that lazily. Implies that
+           * the parent directory exists, no need to note that separately. */
+          update.set_initial_type(ISREG);
+          update.hash_computer_ = &FileUsageUpdate::hash_computer;
+        } else {
+          /* E: Another nasty combo. We can't distinguish a newly created empty file from a
+           * previously empty one. If the file is non-empty, we need to store its hash. Also, the
+           * parent directory has to exist. */
+          update.type_computer_ = &FileUsageUpdate::type_computer_open_wronly_creat_notrunc_noexcl;
+          update.parent_type_ = ISDIR;
+        }
+      }
+      update.parent_type_ = ISDIR;
+      update.written_ = true;
+    } else {
+      /* The file or directory was successfully opened for reading only.
+       * Note that a plain open() can open a directory for reading, even without O_DIRECTORY. */
+      update.type_computer_ = &FileUsageUpdate::type_computer_open_rdonly;
+      update.hash_computer_ = &FileUsageUpdate::hash_computer;
+    }
+  } else /* if (err) */ {
+    /* The attempt to open failed. */
+    if (is_write(flags)) {
+      if (err == ENOENT) {
+        /* When opening a file for writing the absence of the parent dir
+         * results NOTEXIST error. The grandparent dir could be missing as well,
+         * but the missing parent dir would cause the same error thus it will not be a mistake
+         * to shortcut the process if the parent dir is indeed missing. */
+        update.parent_type_ = NOTEXIST;
+      } else if (err == ENOTDIR) {
+        /* Occurs when opening the "foo/baz/bar" path when "foo/baz" is not a directory,
+         * but for example a regular file. Or when "foo" is a regular file. We can't distinguish
+         * between those cases, but if "/foo/baz" is a regular file we can safely shortcut the
+         * process, because the process could not tell the difference either. */
+        update.parent_type_ = ISREG;
+      } else {
+        /* We don't support other errors such as permission denied. */
+        update.unknown_err_ = err;
+        return update;
+      }
+    } else {
+      /* Opening for reading failed. */
+      if (err == ENOENT) {
+        update.set_initial_type(NOTEXIST);
+      } else if (err == ENOTDIR) {
+        /* See the comment in the is_write() branch. */
+        update.parent_type_ = ISREG;
+      } else {
+        /* We don't support other errors such as permission denied. */
+        update.unknown_err_ = err;
+        return update;
+      }
+    }
+  }
+
+  return update;
+}
+
+/**
+ * Based on the parameters and return value of an mkdir() call, returns a FileUsageUpdate object that
+ * reflects how our usage of this file changed.
+ */
+FileUsageUpdate FileUsageUpdate::get_from_mkdir_params(const FileName *filename, int err) {
+  TRACK(FB_DEBUG_PROC, "err=%d", err);
+
+  FileUsageUpdate update(filename);
+
+  if (!err) {
+    update.set_initial_type(NOTEXIST);
+    update.parent_type_ = ISDIR;
+    update.written_ = true;
+  } else {
+    if (err == EEXIST) {
+      /* The directory already exists. It may not be a directory, but in that case process inputs
+       * will not match either. */
+      update.set_initial_type(ISDIR);
+    } else {
+      /* We don't support other errors such as permission denied. */
+      update.unknown_err_ = err;
+    }
+  }
+
+  return update;
+}
+
+/**
+ * Based on the parameters and return value of a stat() or similar call, returns a FileUsageUpdate
+ * object that reflects how our usage of this file changed.
+ */
+FileUsageUpdate FileUsageUpdate::get_from_stat_params(const FileName *filename, mode_t mode,
+                                                      int err) {
+  TRACK(FB_DEBUG_PROC, "mode=%d, err=%d", mode, err);
+
+  FileUsageUpdate update(filename);
+
+  if (!err) {
+    if (S_ISREG(mode)) {
+      update.set_initial_type(ISREG);
+    } else if (S_ISDIR(mode)) {
+      update.set_initial_type(ISDIR);
+    } else {
+      /* Neither regular file nor directory. Pretend for now that there's nothing there. */
+      update.set_initial_type(NOTEXIST);
+    }
+  } else {
+    update.set_initial_type(NOTEXIST);
+  }
+
+  return update;
+}
+
+/* Member debugging method. Not to be called directly, call the global d(obj_or_ptr) instead.
+ * level is the nesting level of objects calling each other's d(), bigger means less info to print.
+ * See #431 for design and rationale. */
+std::string FileUsageUpdate::d_internal(const int level) const {
+  (void)level;  /* unused */
+  return std::string("{FileUsageUpdate initial_state=") + d(initial_state_, level) +
+      (type_computer_ ? ", type_computer=<func>" : "") +
+      (hash_computer_ ? ", hash_computer=<func>" : "") +
+      ", written=" + d(written_) +
+      ", unknown_err=" + d(unknown_err_) + "}";
+}
+
+/* Global debugging methods.
+ * level is the nesting level of objects calling each other's d(), bigger means less info to print.
+ * See #431 for design and rationale. */
+std::string d(const FileUsageUpdate& fuu, const int level) {
+  return fuu.d_internal(level);
+}
+std::string d(const FileUsageUpdate *fuu, const int level) {
+  if (fuu) {
+    return d(*fuu, level);
+  } else {
+    return "{FileUsageUpdate NULL}";
+  }
+}
+
+}  /* namespace firebuild */

--- a/src/firebuild/file_usage_update.h
+++ b/src/firebuild/file_usage_update.h
@@ -1,0 +1,92 @@
+/* Copyright (c) 2022 Interri Kft. */
+/* This file is an unpublished work. All rights reserved. */
+
+#ifndef FIREBUILD_FILE_USAGE_UPDATE_H_
+#define FIREBUILD_FILE_USAGE_UPDATE_H_
+
+#include <string>
+
+#include "firebuild/file_info.h"
+#include "firebuild/file_name.h"
+#include "firebuild/hash.h"
+
+namespace firebuild {
+
+class FileUsageUpdate {
+ public:
+  FileUsageUpdate(const FileName *filename, FileInfo info, bool written = false)
+      : initial_state_(info), filename_(filename), written_(written) {}
+
+  explicit FileUsageUpdate(const FileName *filename, FileType type = DONTKNOW, bool written = false)
+      : initial_state_(type), filename_(filename), written_(written) {}
+
+  static FileUsageUpdate get_from_open_params(const FileName *filename, int flags, int err);
+  static FileUsageUpdate get_from_mkdir_params(const FileName *filename, int err);
+  static FileUsageUpdate get_from_stat_params(const FileName *filename, mode_t mode, int err);
+
+  bool get_initial_type(FileType *type_ptr) const;
+  void set_initial_type(FileType type) {initial_state_.set_type(type);}
+  bool initial_hash_known() const {return initial_state_.hash_known() || hash_computer_ != nullptr;}
+  bool get_initial_hash(Hash *hash_ptr) const;
+  void set_initial_hash(const Hash& hash) {initial_state_.set_hash(hash);}
+
+  FileType parent_type() const {return parent_type_;}
+  bool written() const {return written_;}
+  bool unknown_err() const {return unknown_err_;}
+
+  /* Member debugging method. Not to be called directly, call the global d(obj_or_ptr) instead.
+   * level is the nesting level of objects calling each other's d(), bigger means less info to print.
+   * See #431 for design and rationale. */
+  std::string d_internal(const int level = 0) const;
+
+ private:
+  /* The information we got to know about the file, prior to the changes that potentially occurred
+   * to it.
+   *
+   * If type_computer_ is set then initial_state_.type_ is not yet set to its correct value, it'll
+   * be figured out on demand.
+   *
+   * If hash_computer_ is set then initial_state_.hash_ is not yet set to its correct value, it'll
+   * be figured out on demand. However, initial_state_.hash_known() reports true. */
+  mutable FileInfo initial_state_;
+
+  /* The filename, used when needed to lazily initialize some fields. */
+  const FileName *filename_;
+
+  void type_computer_open_rdonly() const;
+  void type_computer_open_wronly_creat_notrunc_noexcl() const;
+  void hash_computer() const;
+
+  /* If initial_state_'s type_ or hash_ aren't known yet (but in case of hash_ we know that we'll
+   * need to know it), they will be initialized on demand by these methods. */
+  mutable
+      void (FileUsageUpdate::*type_computer_)() const {nullptr};  /* NOLINT(readability/braces) */
+  mutable
+      void (FileUsageUpdate::*hash_computer_)() const {nullptr};  /* NOLINT(readability/braces) */
+
+  /* The file's contents were altered by the process, e.g. written to, or modified in any other way,
+   * including removal of the file, or another file getting renamed to this one. */
+  bool written_ {false};
+
+  /* What we know and are interested in about the parent path. E.g.
+   * - DONTKNOW = nothing of interest
+   * - NOTEXIST = no such entry on the filesystem
+   * - ISDIR = it is a directory
+   * - ISREG = it is a regular file */
+  FileType parent_type_ {DONTKNOW};
+
+  /* This does not strictly obey the semantics of "mutable" because lazy evaluation of
+   * initial_state_.type_ or initial_state_.hash_ might modify it, but I don't think it'll be a
+   * problem, since we don't query this variable before performing the lazy evaluation. */
+  mutable int unknown_err_ {0};
+};
+
+/* Global debugging methods.
+ * level is the nesting level of objects calling each other's d(), bigger means less info to print.
+ * See #431 for design and rationale. */
+std::string d(const FileUsageUpdate& fuu, const int level = 0);
+std::string d(const FileUsageUpdate *fuu, const int level = 0);
+
+}  /* namespace firebuild */
+
+#endif  // FIREBUILD_FILE_USAGE_UPDATE_H_


### PR DESCRIPTION
Fixes #741.

---

Here's the big refactoring I had in mind. It contains the following main changes:

`FileInfo` (let me know if you have a better name idea) is a new building block representing what we know about a given file at a given point. `FileInitialState` was moved here and renamed to `FileType` becase I think "type" is a much better word, and it's not necessarily about the _initial_ type anymore.

`FileUsage` builds upon this, and this one still proxies `FileInfo`'s `type` as `initial_type`, etc., to emphasize that they're about the _initial_ state. Plus it adds the `written_` flag, and IIRC `unknown_err_` too. It no longer represents a change that we merge into the `FileUsage` objects, only the actual accumulated file usage.

The `FileAction` enum is gone, there's something brand new called `FileAction`, or we could call it `FileChange`, `FileUsageChange` etc., pick your favorite. This represents a change (or information that we newly get to know) about a file. This also builds around `FileInfo`. The former `FileAction` enum is replaced by new separate functions `get_from_open_params()`, `get_from_mkdir_params()`, `get_from_stat_params()`. The main feature of this new `FileAction` is the ability to evaluate some values on-demand, the logic being opaquely encapsulated in this class. This is important with forthcoming `stat()` support, because in the old code the switch from the `FileAction` enum (with partial information) to the `FileChange` object (with everything that will potentially be required) happened at one place: when we're about to register it for the first time. But with size and permissions support it might happen that we need to figure out some bits of information on demand one by one, not necessarily all of them at once, and we don't necessarily know in advance what exactly we'll need.

The register/propagate (bubbling up) logic become significantly simpler, built around the "shortcut trick" I mentioned in the opening bugreport. I also modified the code to make bigger jumps, i.e. to always proceed with the next shortcuttable ancestor rather than the next exec point.

Handling the implicit parent directory is also nicer: The decision what to do with them used to be scattered around (some in `process.cc` `handle_foo()`, some in `execed_process.cc` `register_file_usage()`, now the decision is always in `FileAction`, and `register_file_usage()` only executes that decision.


