### PR TITLE
interceptor: Don't use builtin_apply() for fcntl(), ioctl() and clone()

### DIFF
--- a/src/interceptor/CMakeLists.txt
+++ b/src/interceptor/CMakeLists.txt
@@ -16,6 +16,7 @@ add_custom_command (
   OUTPUT gen_decl.h gen_def.c gen_impl.c gen_init.c gen_list.txt gen_reset.c
   DEPENDS generate_interceptors
   tpl.c
+  tpl_clone.c
   tpl_dlopen.c
   tpl_dup2.c
   tpl_error.c

--- a/src/interceptor/tpl.c
+++ b/src/interceptor/tpl.c
@@ -197,11 +197,7 @@ ic_orig_{{ func }} = ({{ rettype }}(*)({{ sig_str }})) dlsym(RTLD_NEXT, "{{ func
   {%+ if rettype != 'void' %}ret = {% endif -%}
   ic_orig_{{ func }}({{ names_str }});
 ###           else
-  void *args = __builtin_apply_args();
-  {%+ if rettype != 'void' %}void const * const result ={% endif -%}
-  __builtin_apply((void *) ic_orig_{{ func }}, args, 100);
-  {%+ if rettype != 'void' %}ret = *({{ rettype }}*)result;{% endif %}
-
+#error "Need to implement call_orig for vararg function {{ func }}()"
 ###           endif
 ###         endif
 ###       endblock call_orig

--- a/src/interceptor/tpl_clone.c
+++ b/src/interceptor/tpl_clone.c
@@ -9,11 +9,35 @@
 {% set msg_skip_fields = ["fn", "stack", "flags", "arg"] %}
 
 ### block before
-  /* seemingly unused, actually used via __builtin_apply_args */
-  (void) fn;
-  (void) stack;
   /* clone() can be really tricky to intercept, for example when the cloned process shares
    * the file descriptor table with the parent (CLONE_FILES). In this case the interceptor
    * would have to protect two communication fds or implement locking across separate processes. */
   intercepting_enabled = false;
 ### endblock before
+
+### block call_orig
+  int vararg_count = 0;
+  if (flags & (CLONE_CHILD_CLEARTID | CLONE_CHILD_SETTID)) {
+    vararg_count = 3;
+  } else if (flags & CLONE_SETTLS) {
+    vararg_count = 2;
+  } else if (flags & (CLONE_PARENT_SETTID | CLONE_PIDFD)) {
+    vararg_count = 1;
+  }
+  if (vararg_count == 0) {
+    ret = ic_orig_{{ func }}(fn, stack, flags, arg);
+  } else {
+    pid_t *parent_tid = va_arg(ap, pid_t *);
+    if (vararg_count == 1) {
+      ret = ic_orig_{{ func }}(fn, stack, flags, arg, parent_tid);
+    } else {
+      void *tls = va_arg(ap, void *);
+      if (vararg_count == 2) {
+        ret = ic_orig_{{ func }}(fn, stack, flags, arg, parent_tid, tls);
+      } else {
+        pid_t *child_tid = va_arg(ap, pid_t *);
+        ret = ic_orig_{{ func }}(fn, stack, flags, arg, parent_tid, tls, child_tid);
+      }
+    }
+  }
+### endblock call_orig

--- a/src/interceptor/tpl_fcntl.c
+++ b/src/interceptor/tpl_fcntl.c
@@ -61,7 +61,11 @@
     case F_SETFD: {
       to_send = true;
       has_int_arg = true;
-      int_arg = va_arg(ap, int);
+      /* Start another vararg business that doesn't conflict with the one in call_orig, see #178. */
+      va_list ap_int;
+      va_start(ap_int, cmd);
+      int_arg = va_arg(ap_int, int);
+      va_end(ap_int);
       break;
     }
 
@@ -76,3 +80,9 @@
     }
   }
 ### endblock before
+
+### block call_orig
+  /* Treating the optional parameter as 'void *' should work, see #178. */
+  void *voidp_arg = va_arg(ap, void *);
+  ret = ic_orig_{{ func }}(fd, cmd, voidp_arg);
+### endblock call_orig

--- a/src/interceptor/tpl_ioctl.c
+++ b/src/interceptor/tpl_ioctl.c
@@ -28,3 +28,9 @@
     }
   }
 ### endblock before
+
+### block call_orig
+  /* Treating the optional parameter as 'void *' should work, see #178. */
+  void *voidp_arg = va_arg(ap, void *);
+  ret = ic_orig_{{ func }}(fd, cmd, voidp_arg);
+### endblock call_orig

--- a/src/interceptor/tpl_syscall.c
+++ b/src/interceptor/tpl_syscall.c
@@ -53,3 +53,10 @@
       }
   }
 ### endblock no_intercept
+
+### block call_orig
+  /* FIXME Find a different solution, see #178. */
+  void *args = __builtin_apply_args();
+  void const * const result = __builtin_apply((void *) ic_orig_{{ func }}, args, 100);
+  ret = *({{ rettype }}*)result;
+### endblock call_orig


### PR DESCRIPTION
Improves #178.