### PR TITLE
supervisor: Fix registering file usage update when report is generated

### DIFF
--- a/src/firebuild/execed_process.cc
+++ b/src/firebuild/execed_process.cc
@@ -303,7 +303,7 @@ bool ExecedProcess::register_file_usage_update(const FileName *name,
     if (!generate_report) {
       proc = proc->next_shortcutable_ancestor();
     } else {
-      proc = proc->exec_point();
+      proc = proc->parent_exec_point();
     }
   }
   return true;


### PR DESCRIPTION
Seems to be a regression caused by the refactoring in
0d81e68698a80e1122626a21bae7d74b022b353d.