### PR TITLE
interceptor: Translate _Fork() calls to fork()

### DIFF
--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -1251,7 +1251,8 @@ skip("exit_group")
 # Intercept fork and vfork
 generate("pid_t", "fork", "",
          tpl="fork")
-generate("pid_t", "vfork", "",
+# NOTE: Mapping those to fork() breaks the ABI since the fork handlers were not supposed to run for those calls.
+generate("pid_t", ["vfork", "_Fork"], "",
          tpl="fork")
 
 # Intercept system

--- a/test/test_symbols
+++ b/test/test_symbols
@@ -52,8 +52,9 @@ fi
 
 # Get the list of libc, libdl and libpthread symbols.
 
-# Some symbols have been removed from glibc
-known_extra="stime
+# Some symbols have been removed from or introduced recently to glibc
+known_extra="_Fork
+stime
 ustat"
 # TODO(rbalint) provide properly versioned symbols in libfirebuild
 libs=$(LD_PRELOAD=libpthread.so.0 ldd "$binary_dir/src/interceptor/libfirebuild.so" | egrep 'lib(c|dl|pthread).so' | cut -d' ' -f3)


### PR DESCRIPTION
This breaks the ABI because fork handlers are run even when the intercepted
program calls _Fork(), but the interceptor already breaks the ABI the same way
when mapping vfork() to fork().

Fixes #578.