### PR TITLE
tests: Set ld's -flto=auto in parallel make instead of -flto=jobserver

### DIFF
--- a/test/test_parallel_make.Makefile
+++ b/test/test_parallel_make.Makefile
@@ -10,7 +10,7 @@ parallel_make_test_main.c:
 # Note the '+' prefix before the commad. This makes make keep the jobserver pipe open even when not invoking a sub-make.
 # See: https://savannah.gnu.org/bugs/?47392
 parallel_make_test_main: parallel_make_test_main.c $(patsubst %,parallel_make_test.%.o,$(shell seq 8))
-	+gcc -flto=jobserver -o $@ $^
+	+gcc -flto=auto -o $@ $^
 
 clean:
 	rm -f parallel_make_test.*.? parallel_make_test_main*


### PR DESCRIPTION
This does not complain when MAKEFLAGS is not set, like on Ubuntu 22.04.