### PR TITLE
Don't shortcut stat and ls

### DIFF
--- a/etc/firebuild.conf
+++ b/etc/firebuild.conf
@@ -25,7 +25,9 @@ processes = {
     // Part of the file information returned by stat() e.g. inode number is ignored
     // for shortcutting purposes and is not stored in the cache. As a result the stat command
     // would very often provide invalid output when shortcut thus it is safer to just not shortcut it.
-    "stat"
+    "stat",
+    // The ls command can print inodes and other ignored file information, too.
+    "ls"
   ];
 
   // Processes that should not be intercepted. This means that they and their ancestors
@@ -48,7 +50,7 @@ processes = {
     // coreutils
     "arch", "basename", "cat", "chgrp", "chmod", "chown", "cp", "cut",
     "dd", "dir", "dirname", "expr", "head", "install", "link", "ln",
-    "ls", "mkdir", "mv", "readlink", "realpath", "rm", "rmdir",
+    "mkdir", "mv", "readlink", "realpath", "rm", "rmdir",
     "seq", "tail", "touch", "tr", "unlink",
     // usually shell builtins, but not always
     "[", "echo", "false", "printf", "pwd", "test", "true",

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -13,7 +13,7 @@ setup() {
 
 @test "bash -c ls" {
   for i in 1 2; do
-    result=$(./run-firebuild -- bash -c "ls integration.bats")
+    result=$(./run-firebuild -o 'processes.dont_shortcut -= "ls"'  -- bash -c "ls integration.bats")
     assert_streq "$result" "integration.bats"
     assert_streq "$(strip_stderr stderr)" ""
   done
@@ -29,14 +29,14 @@ setup() {
 
 @test "debugging with trace markers and report generation" {
   for i in 1 2; do
-    result=$(./run-firebuild -r -d all -i -- bash -c "ls integration.bats; bash -c ls | tee dirlist > /dev/null")
+    result=$(./run-firebuild -o 'processes.dont_shortcut -= "ls"' -r -d all -i -- bash -c "ls integration.bats; bash -c ls | tee dirlist > /dev/null")
     assert_streq "$result" "integration.bats"
   done
 }
 
 @test "bash exec chain" {
   for i in 1 2; do
-    result=$(./run-firebuild -- bash -c "exec bash -c exec\\ bash\\ -c\\ ls\\\\\ integration.bats")
+    result=$(./run-firebuild -o 'processes.dont_shortcut -= "ls"' -- bash -c "exec bash -c exec\\ bash\\ -c\\ ls\\\\\ integration.bats")
     assert_streq "$result" "integration.bats"
     assert_streq "$(strip_stderr stderr)" ""
   done


### PR DESCRIPTION
I liked that we shortcut ls because it was a good demo command, but it is still more important to be right, sigh. :-)