### PR TITLE
supervisor: Don't use strlen() in path_is_absolute()

### DIFF
--- a/src/firebuild/platform.h
+++ b/src/firebuild/platform.h
@@ -21,7 +21,7 @@ inline bool path_is_absolute(const char * p) {
 #ifdef _WIN32
   return !PathIsRelative(p);
 #else
-  if ((strlen(p) >= 1) && (p[0] == '/')) {
+  if (p[0] == '/') {
     return true;
   } else {
     return false;


### PR DESCRIPTION
That does not yield any measurable improvement, but was really ugly.