### PR TITLE
supervisor: Do not send early ACKs

### DIFF
--- a/src/firebuild/process.cc
+++ b/src/firebuild/process.cc
@@ -207,16 +207,20 @@ int Process::handle_open(const int dirfd, const char * const ar_name, const size
     name->close_for_writing();
   }
 
-  if (ack_num != 0) {
-    ack_msg(fd_conn, ack_num);
-  }
-
   FileUsageUpdate update = FileUsageUpdate::get_from_open_params(name, flags, error);
   if (!exec_point()->register_file_usage_update(name, update)) {
     exec_point()->disable_shortcutting_bubble_up("Could not register the opening of a file", *name);
+    if (ack_num != 0) {
+      ack_msg(fd_conn, ack_num);
+    }
     return -1;
   }
 
+  /* handle_open() is designed to possibly send an early ACK. However it doesn't do so currently,
+   * until we figure out #878 / #879. It always sends the ACK just before returning. */
+  if (ack_num != 0) {
+    ack_msg(fd_conn, ack_num);
+  }
   return 0;
 }
 


### PR DESCRIPTION
Fixes #878.

Please do a code review.

Let's do a round of perftest before merging (I'll do one, you can do too if you wish).

I measured two versions last night, the `access` branch (without this change) and the `chmod` change (which goes on top of `access`, plus the chmod bits, plus this change). Looking at the graphs, only `glib2.0` showed a visible increase. Could be related to the `chmod` changes, so let's run a perftest measuring this change only.