### PR TITLE
interceptor: Fix disabling interception on clone()

### DIFF
--- a/src/common/debug_sysflags.c
+++ b/src/common/debug_sysflags.c
@@ -5,6 +5,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <sched.h>
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -426,6 +427,40 @@ void debug_wstatus(FILE *f, int wstatus) {
     sep = ", ";
   }
   fprintf(f, ")");
+}
+
+/**
+ * Debug-print CLONE_* flags, as usually seen in the 'flags' parameter of clone().
+ */
+void debug_clone_flags(FILE *f, int flags) {
+  DEBUG_BITMAP_START(f, flags);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_VM);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_FS);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_FILES);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_SIGHAND);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_PIDFD);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_PTRACE);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_VFORK);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_PARENT);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_THREAD);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_NEWNS);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_SYSVSEM);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_SETTLS);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_PARENT_SETTID);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_CHILD_CLEARTID);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_DETACHED);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_UNTRACED);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_CHILD_SETTID);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_NEWCGROUP);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_NEWUTS);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_NEWIPC);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_NEWUSER);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_NEWPID);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_NEWNET);
+  DEBUG_BITMAP_FLAG(f, flags, CLONE_IO);
+  DEBUG_BITMAP_END_HEX(f, flags & ~0xff);
+  fprintf(f, "|");
+  debug_signum(f, flags & 0xff);
 }
 
 #ifdef __cplusplus

--- a/src/common/debug_sysflags.h
+++ b/src/common/debug_sysflags.h
@@ -24,6 +24,7 @@ void debug_error_no(FILE *f, int error_no);
 void debug_signum(FILE *f, int signum);
 void debug_mode_t(FILE *f, mode_t mode);
 void debug_wstatus(FILE *f, int wstatus);
+void debug_clone_flags(FILE *f, int flags);
 
 #ifdef __cplusplus
 }  /* extern "C" */

--- a/src/common/fbbcomm.def
+++ b/src/common/fbbcomm.def
@@ -71,6 +71,16 @@
       debug_fcntl_arg_or_ret(f, cmd, arg_or_ret);
       fprintf(f, "\\"");
     }
+
+    /* Debugger method for int fields that represent CLONE_* flags. */
+    static void fbbcomm_debug_clone_flags(FILE *f, int flags, bool is_serialized, const void *fbb) {
+      (void)is_serialized;  /* unused */
+      (void)fbb;  /* unused */
+      fprintf(f, "\\"");
+      debug_clone_flags(f, flags);
+      fprintf(f, "\\"");
+    }
+
   """,
 
   "extra_h": """
@@ -823,7 +833,9 @@
     ]),
 
     # disables interception and shortcutting
-    ("clone", []),
+    ("clone", [
+      (REQUIRED, "int", "flags", "fbbcomm_debug_clone_flags"),
+    ]),
 
 
     # reading from /dev/urandom is allowed (GRND_RANDOM flag not set)

--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -1447,7 +1447,6 @@ generate("int", "posix_spawn_file_actions_addfchdir_np", "posix_spawn_file_actio
 
 # Insert a trace marker for clone and pthread_create
 generate("int", "clone", "int (*fn)(void *), void *stack, int flags, void *arg, ...",
-         send_msg_on_error=False,
          tpl="clone")
 generate("int", "pthread_create", "pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void *), void *arg",
          tpl="pthread_create")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,7 @@ add_custom_target(valgrind-check env FIREBUILD_PREFIX_CMD='valgrind -q --leak-ch
 add_test_binary(test_cmd_fork_exec)
 add_test_binary(test_cmd_popen)
 add_test_binary(test_cmd_posix_spawn)
+add_test_binary(test_cmd_clone)
 add_test_binary(test_cmd_system)
 add_test_binary(test_system)
 add_test_binary(test_exec)

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -240,6 +240,16 @@ setup() {
   done
 }
 
+@test "clone() a statically linked binary" {
+  ldd ./test_static 2>&1 | egrep -q '(not a dynamic executable|statically linked)'
+
+  for i in 1 2; do
+    result=$(./run-firebuild -- ./test_cmd_clone ./test_static)
+    assert_streq "$result" "I am statically linked."
+    assert_streq "$(strip_stderr stderr)" ""
+  done
+}
+
 @test "system() a statically linked binary" {
   ldd ./test_static 2>&1 | egrep -q '(not a dynamic executable|statically linked)'
 

--- a/test/test_cmd_clone.c
+++ b/test/test_cmd_clone.c
@@ -1,0 +1,51 @@
+/* Copyright (c) 2020 Interri Kft. */
+/* This file is an unpublished work. All rights reserved. */
+
+/* Based on clone(2) man page. */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <sched.h>
+#include <stdio.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define STACK_SIZE (1024 * 1024)    /* Stack size for cloned child */
+
+/* Performs a clone() / waitpid() pair.
+ * The command executes and its parameter taken from the command line.
+ * Returns 0 (unless an error occurred), not the command's exit code. */
+
+int child(void *arg) {
+  return execv(*(char**)arg, (char**)arg);
+}
+
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    fprintf(stderr, "need at least 1 argument\n");
+    return 1;
+  }
+
+  char *stack, *stack_top;
+  stack = mmap(NULL, STACK_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK,
+               -1, 0);
+  if (stack == MAP_FAILED) {
+    perror("mmap");
+    return 1;
+  }
+  stack_top = stack + STACK_SIZE;
+  int ret = clone(child, stack_top, CLONE_PTRACE|SIGCHLD, &argv[1]);
+  if (ret == -1) {
+    errno = ret;
+    perror("clone");
+    return 1;
+  }
+
+  if (waitpid(ret, NULL, 0) < 0) {
+    perror("waitpid");
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Clear the environment, to disable children's interception, too.
Also send the the clone message to the supervisor _before_ disabling
interception and before the actual clone() call.

Improves #644.