### PR TITLE
firebuild: Track and restore file permissions

### DIFF
--- a/src/common/fbbcomm.def
+++ b/src/common/fbbcomm.def
@@ -352,7 +352,7 @@
       # file path
       (OPTIONAL, STRING, "path"),
       # mode
-      (OPTIONAL, "mode_t", "mode"),
+      (REQUIRED, "mode_t", "mode"),
       # flags for fchmodat(), AT_SYMLINK_NOFOLLOW for lchmod()
       (OPTIONAL, "int", "flags", "fbbcomm_debug_at_flags"),
       # error no., when ret = -1
@@ -361,9 +361,9 @@
 
     ("fchmod", [
       # file fd
-      (OPTIONAL, "int", "fd"),
+      (REQUIRED, "int", "fd"),
       # mode
-      (OPTIONAL, "mode_t", "mode"),
+      (REQUIRED, "mode_t", "mode"),
       # error no., when ret = -1
       (OPTIONAL, "int", "error_no"),
     ]),

--- a/src/firebuild/execed_process.cc
+++ b/src/firebuild/execed_process.cc
@@ -98,10 +98,11 @@ void ExecedProcess::initialize() {
   /* Propagate the opening of the executable and libraries upwards as
    * regular file open events. */
   if (parent_exec_point()) {
-    FileUsageUpdate exe_update = FileUsageUpdate::get_from_open_params(executable(), O_RDONLY, 0);
+    FileUsageUpdate exe_update =
+        FileUsageUpdate::get_from_open_params(executable(), O_RDONLY, 0, 0);
     parent_exec_point()->register_file_usage_update(executable(), exe_update);
     for (const auto& lib : libs_) {
-      FileUsageUpdate lib_update = FileUsageUpdate::get_from_open_params(lib, O_RDONLY, 0);
+      FileUsageUpdate lib_update = FileUsageUpdate::get_from_open_params(lib, O_RDONLY, 0, 0);
       parent_exec_point()->register_file_usage_update(lib, lib_update);
     }
   }

--- a/src/firebuild/file_usage_update.h
+++ b/src/firebuild/file_usage_update.h
@@ -24,12 +24,14 @@ class FileUsageUpdate {
       : initial_state_(type), filename_(filename), written_(written), mode_changed_(mode_changed),
         generation_(filename->generation()) {}
 
-  static FileUsageUpdate get_from_open_params(const FileName *filename, int flags, int err);
+  static FileUsageUpdate get_from_open_params(const FileName *filename, int flags,
+                                              mode_t mode_with_umask, int err);
   static FileUsageUpdate get_from_mkdir_params(const FileName *filename, int err);
   static FileUsageUpdate get_from_stat_params(const FileName *filename, mode_t mode, off_t size,
                                               int err);
   static FileUsageUpdate get_oldfile_usage_from_rename_params(const FileName* old_name,
                                                               const FileName* new_name, int err);
+  static FileUsageUpdate get_newfile_usage_from_rename_params(const FileName* new_name, int err);
 
   FileType parent_type() const {return parent_type_;}
   bool written() const {return written_;}

--- a/src/firebuild/firebuild.cc
+++ b/src/firebuild/firebuild.cc
@@ -889,8 +889,9 @@ void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf,
             const size_t path_len = action_open->get_path_len();
             int fd = action_open->get_fd();
             int flags = action_open->get_flags();
+            mode_t mode = action_open->get_mode();
             fork_child->handle_force_close(fd);
-            fork_child->handle_open(AT_FDCWD, path, path_len, flags, fd, 0);
+            fork_child->handle_open(AT_FDCWD, path, path_len, flags, mode, fd, 0);
             /* Revert the effect of "pre-opening" paths to be written in the posix_spawn message.*/
             if (is_write(flags)) {
               const firebuild::FileName* file_name = fork_child->get_absolute(AT_FDCWD, path,
@@ -1211,6 +1212,16 @@ void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf,
           reinterpret_cast<const FBBCOMM_Serialized_faccessat *>(fbbcomm_buf));
       break;
     }
+    case FBBCOMM_TAG_chmod: {
+      ::firebuild::ProcessFBBAdaptor::handle(proc,
+          reinterpret_cast<const FBBCOMM_Serialized_chmod *>(fbbcomm_buf));
+      break;
+    }
+    case FBBCOMM_TAG_fchmod: {
+      ::firebuild::ProcessFBBAdaptor::handle(proc,
+          reinterpret_cast<const FBBCOMM_Serialized_fchmod *>(fbbcomm_buf));
+      break;
+    }
     case FBBCOMM_TAG_memfd_create: {
       ::firebuild::ProcessFBBAdaptor::handle(proc,
           reinterpret_cast<const FBBCOMM_Serialized_memfd_create *>(fbbcomm_buf));
@@ -1279,11 +1290,9 @@ void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf,
       proc->exec_point()->disable_shortcutting_bubble_up("clone() is not supported");
       break;
     }
-    case FBBCOMM_TAG_chmod:
     case FBBCOMM_TAG_chown:
     case FBBCOMM_TAG_fb_debug:
     case FBBCOMM_TAG_fb_error:
-    case FBBCOMM_TAG_fchmod:
     case FBBCOMM_TAG_fchown:
     case FBBCOMM_TAG_fpathconf:
     case FBBCOMM_TAG_ftruncate:

--- a/src/firebuild/process.h
+++ b/src/firebuild/process.h
@@ -232,6 +232,7 @@ class Process {
    * @param ar_name relative or absolute file name
    * @param ar_len length of ar_name
    * @param flags flags of open()
+   * @param mode mode (create permissions) of open()
    * @param fd the return value, or -1 if file was dlopen()ed successfully
    * @param error error code of open()
    * @param fd_conn fd to send ACK on when needed
@@ -239,7 +240,7 @@ class Process {
    * @param pre_open_sent interceptor already sent pre_open for this open
    */
   int handle_open(const int dirfd, const char * const ar_name, const size_t ar_len, const int flags,
-                  const int fd, const int error = 0, int fd_conn = -1,
+                  const mode_t mode, const int fd, const int error = 0, int fd_conn = -1,
                   int ack_num = 0, const bool pre_open_sent = false);
 
   /**
@@ -331,6 +332,11 @@ class Process {
    */
   int handle_faccessat(const int dirfd, const char * const name, const size_t name_len,
                        const int mode, const int flags, const int error = 0);
+
+  int handle_chmod(const int dirfd, const char * const name, const size_t name_len,
+                   const mode_t mode, const int flags, const int error = 0);
+
+  int handle_fchmod(const int fd, const mode_t mode, const int error = 0);
 
   /**
    * Handle memfd_create in the monitored process

--- a/src/firebuild/process_fbb_adaptor.cc
+++ b/src/firebuild/process_fbb_adaptor.cc
@@ -20,7 +20,8 @@ int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_open *msg,
   int error = msg->get_error_no_with_fallback(0);
   int ret = msg->get_ret_with_fallback(-1);
   return proc->handle_open(dirfd, msg->get_file(), msg->get_file_len(), msg->get_flags(),
-                           ret, error, fd_conn, ack_num, msg->get_pre_open_sent());
+                           msg->get_mode_with_fallback(0), ret, error, fd_conn, ack_num,
+                           msg->get_pre_open_sent());
 }
 
 int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_freopen *msg, int fd_conn,
@@ -37,7 +38,7 @@ int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_dlopen *ms
   if (!msg->has_error_string() && msg->has_absolute_filename()) {
     return proc->handle_open(AT_FDCWD,
                              msg->get_absolute_filename(), msg->get_absolute_filename_len(),
-                             O_RDONLY, -1, 0, fd_conn, ack_num);
+                             O_RDONLY, 0, -1, 0, fd_conn, ack_num);
   } else {
     std::string filename = msg->has_absolute_filename() ? msg->get_absolute_filename() : "NULL";
     proc->exec_point()->disable_shortcutting_bubble_up("Process failed to dlopen() ", filename);
@@ -102,6 +103,22 @@ int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_faccessat 
   const int error = msg->get_error_no_with_fallback(0);
   return proc->handle_faccessat(dirfd, msg->get_pathname(), msg->get_pathname_len(),
                                 mode, flags, error);
+}
+
+int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_chmod *msg) {
+  const int dirfd = msg->get_dirfd_with_fallback(AT_FDCWD);
+  const mode_t mode = msg->get_mode();
+  const int flags = msg->get_flags_with_fallback(0);
+  const int error = msg->get_error_no_with_fallback(0);
+  return proc->handle_chmod(dirfd, msg->get_path(), msg->get_path_len(),
+                            mode, flags, error);
+}
+
+int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_fchmod *msg) {
+  const int fd = msg->get_fd();
+  const int mode = msg->get_mode();
+  const int error = msg->get_error_no_with_fallback(0);
+  return proc->handle_fchmod(fd, mode, error);
 }
 
 int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_memfd_create *msg) {

--- a/src/firebuild/process_fbb_adaptor.h
+++ b/src/firebuild/process_fbb_adaptor.h
@@ -31,6 +31,8 @@ class ProcessFBBAdaptor {
   static int handle(Process *proc, const FBBCOMM_Serialized_fstat *msg);
   static int handle(Process *proc, const FBBCOMM_Serialized_stat *msg);
   static int handle(Process *proc, const FBBCOMM_Serialized_faccessat *msg);
+  static int handle(Process *proc, const FBBCOMM_Serialized_chmod *msg);
+  static int handle(Process *proc, const FBBCOMM_Serialized_fchmod *msg);
   static int handle(Process *proc, const FBBCOMM_Serialized_memfd_create *msg);
   static int handle(Process *proc, const FBBCOMM_Serialized_timerfd_create *msg);
   static int handle(Process *proc, const FBBCOMM_Serialized_epoll_create *msg);


### PR DESCRIPTION
Add support for [f]chmod(). Track when a file's permissions potentially
change, including open(O_CREAT) and creat(). Save the final permissions
in the cache and restore them when shortcutting.

Fixes #668, obsoletes #861.

---

Please do a preliminary review. It's "almost ready".

This is the chmod(), creat() and friends all-in-one. It would be hard to
split into 2-3 roughly equally sized steps which would work perfectly
with a decent performance.

I measured the performance of a WIP version that didn't yet support
fchmod() (only chmod()), and had a quick fix (revert) for 880.

The graphs look okay, except for the second build of acl and attr. To be
investigated. First let's run a perftest with the current state.

I'll post numbers and graphs in a sec.

Please take a look. It'll definite need a little bit of work, e.g. I
have a FIXME at one place where setting the `generation`, I need your
help there.

There's unfortunately some code duplication between chmod() and fchmod(),
this will be cleaned up in 851.