### PR TITLE
Revert "firebuild: Don't shortcut the sleep command by default"

### DIFF
--- a/etc/firebuild.conf
+++ b/etc/firebuild.conf
@@ -22,9 +22,10 @@ processes = {
   dont_shortcut = [
     // orchestrating tools that compare timestamps
     "make", "ninja",
-    // sleep is used sometimes to provide periodic status of the build, which breaks if sleep is shortcut
-    // and becomes very short
-    "sleep",
+    // Sleep is used sometimes to provide periodic status of the build, which breaks if sleep is shortcut
+    // and finish very fast. By default the sleep command is shortcut. Disable shortcutting if your build
+    // system relies on sleep's original behavior.
+    // "sleep",
     // Part of the file information returned by stat() e.g. inode number is ignored
     // for shortcutting purposes and is not stored in the cache. As a result the stat command
     // would very often provide invalid output when shortcut thus it is safer to just not shortcut it.

--- a/test/run-firebuild.in
+++ b/test/run-firebuild.in
@@ -4,7 +4,6 @@
 
 env FIREBUILD_DATA_DIR="@CMAKE_SOURCE_DIR@/data" $FIREBUILD_PREFIX_CMD firebuild \
   -c @CMAKE_BINARY_DIR@/etc/firebuild.conf \
-  -o 'processes.dont_shortcut -= "sleep"' \
   -o 'env_vars.pass_through += "GCOV_PREFIX"' \
   -o 'env_vars.pass_through += "GCOV_PREFIX_STRIP"' \
   -o "ignore_locations += \"$GCOV_PREFIX\"" \


### PR DESCRIPTION
This reverts commit ae7b50bc60a3f217cc75c29dd4f32f9be800df60.

Apparently bash's builde uses sleep as well. Let's shortcut sleep, too,
projects relying on sleep's behavior can disable shortcutting sleep.