### PR TITLE
firebuild: Use more consistent internal terminology

### DIFF
--- a/src/common/fbbcomm.def
+++ b/src/common/fbbcomm.def
@@ -187,14 +187,14 @@
       # dir file descriptor for openat()
       (OPTIONAL, "int", "dirfd"),
       # file path
-      (OPTIONAL, STRING, "file"),
+      (OPTIONAL, STRING, "pathname"),
     ]),
 
     ("open", [
       # dir file descriptor for openat()
       (OPTIONAL, "int", "dirfd"),
       # file path
-      (OPTIONAL, STRING, "file"),
+      (OPTIONAL, STRING, "pathname"),
       # flags, decoding is left for Firebuild supervisor
       (REQUIRED, "int", "flags", "fbbcomm_debug_open_flags"),
       # mode if (flags & O_CREAT), decoding is left for Firebuild supervisor
@@ -209,7 +209,7 @@
 
     ("freopen", [
       # file path, can be NULL
-      (OPTIONAL, STRING, "file"),
+      (OPTIONAL, STRING, "pathname"),
       # flags, decoding is left for Firebuild supervisor
       (OPTIONAL, "int", "flags", "fbbcomm_debug_open_flags"),
       # file descriptor associated to the stream to be reopened
@@ -224,7 +224,7 @@
 
     ("chdir", [
       # directory path
-      (OPTIONAL, STRING, "dir"),
+      (OPTIONAL, STRING, "pathname"),
       # error no., when ret = -1
       (OPTIONAL, "int", "error_no"),
     ]),
@@ -240,11 +240,11 @@
       # dir file descriptor for readlinkat()
       (OPTIONAL, "int", "dirfd"),
       # path name
-      (OPTIONAL, STRING, "path"),
+      (OPTIONAL, STRING, "pathname"),
       # buffer size
       (OPTIONAL, "size_t", "bufsiz"),
       # returned path
-      (OPTIONAL, STRING, "ret_path"),
+      (OPTIONAL, STRING, "ret_target"),
       # error no., when ret = -1
       (OPTIONAL, "int", "error_no"),
     ]),
@@ -281,7 +281,7 @@
       # dir file descriptor for fstatat()
       (OPTIONAL, "int", "dirfd"),
       # path to file
-      (OPTIONAL, STRING, "filename"),
+      (OPTIONAL, STRING, "pathname"),
       # it could be lstat() encoded as AT_SYMLINK_NOFOLLOW or fstatat(..., flags)
       (OPTIONAL, "int", "flags", "fbbcomm_debug_at_flags"),
       # Returned file type and mode
@@ -350,7 +350,7 @@
       # dir file descriptor for fchmodat()
       (OPTIONAL, "int", "dirfd"),
       # file path
-      (OPTIONAL, STRING, "path"),
+      (OPTIONAL, STRING, "pathname"),
       # mode
       (REQUIRED, "mode_t", "mode"),
       # flags for fchmodat(), AT_SYMLINK_NOFOLLOW for lchmod()
@@ -372,7 +372,7 @@
       # dir file descriptor for fchownat()
       (OPTIONAL, "int", "dirfd"),
       # file path
-      (OPTIONAL, STRING, "path"),
+      (OPTIONAL, STRING, "pathname"),
       # uid
       (OPTIONAL, "uid_t", "owner"),
       # gid
@@ -424,7 +424,7 @@
 
     ("symlink", [
       # old file path
-      (OPTIONAL, STRING, "oldpath"),
+      (OPTIONAL, STRING, "target"),
       # new dir file descriptor for symlinkat()
       (OPTIONAL, "int", "newdirfd"),
       # new file path
@@ -448,7 +448,7 @@
       # ..at(), like utimensat
       (OPTIONAL, "int", "dirfd"),
       # file name
-      (OPTIONAL, STRING, "file"),
+      (OPTIONAL, STRING, "pathname"),
       # all timestamps should be set to current time
       (REQUIRED, "bool", "all_utime_now"),
       # flags for utimensat(), AT_SYMLINK_NOFOLLOW for lutimes()
@@ -638,7 +638,7 @@
     ("posix_spawn_file_action_open", [
       (REQUIRED, "int", "fd"),
       # Note: path is not absolute!
-      (REQUIRED, STRING,    "path"),
+      (REQUIRED, STRING, "pathname"),
       (REQUIRED, "int", "flags", "fbbcomm_debug_open_flags"),
       (REQUIRED, "mode_t", "mode"),
     ]),
@@ -665,7 +665,7 @@
     # This is not used as a toplevel message, but in the "file_actions" field of a
     # "posix_spawn_parent" message, corresponding to an earlier posix_spawn_file_actions_addchdir_np() call.
     ("posix_spawn_file_action_chdir", [
-      (REQUIRED, STRING, "path"),
+      (REQUIRED, STRING, "pathname"),
     ]),
 
     # This is not used as a toplevel message, but in the "file_actions" field of a
@@ -758,7 +758,7 @@
 
     ("truncate", [
       # name
-      (OPTIONAL, STRING, "path"),
+      (OPTIONAL, STRING, "pathname"),
       # length
       (OPTIONAL, "off_t", "len"),
       # error no., when ret = -1

--- a/src/firebuild/firebuild.cc
+++ b/src/firebuild/firebuild.cc
@@ -850,7 +850,7 @@ void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf,
             int flags = action_open->get_flags();
             if (is_write(flags)) {
               const firebuild::FileName* file_name = proc->get_absolute(
-                  AT_FDCWD, action_open->get_path(), action_open->get_path_len());
+                  AT_FDCWD, action_open->get_pathname(), action_open->get_pathname_len());
               if (file_name) {
                 /* Pretend that the parent opened the file for writing and not the fork child.
                  * This is not accurate, but the fork child does not exist yet. A parallel
@@ -885,17 +885,17 @@ void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf,
             /* A successful open to a particular fd, silently closing the previous file if any. */
             const FBBCOMM_Serialized_posix_spawn_file_action_open *action_open =
                 reinterpret_cast<const FBBCOMM_Serialized_posix_spawn_file_action_open *>(action);
-            const char *path = action_open->get_path();
-            const size_t path_len = action_open->get_path_len();
+            const char *pathname = action_open->get_pathname();
+            const size_t pathname_len = action_open->get_pathname_len();
             int fd = action_open->get_fd();
             int flags = action_open->get_flags();
             mode_t mode = action_open->get_mode();
             fork_child->handle_force_close(fd);
-            fork_child->handle_open(AT_FDCWD, path, path_len, flags, mode, fd, 0);
+            fork_child->handle_open(AT_FDCWD, pathname, pathname_len, flags, mode, fd, 0);
             /* Revert the effect of "pre-opening" paths to be written in the posix_spawn message.*/
             if (is_write(flags)) {
-              const firebuild::FileName* file_name = fork_child->get_absolute(AT_FDCWD, path,
-                                                                              path_len);
+              const firebuild::FileName* file_name = fork_child->get_absolute(AT_FDCWD, pathname,
+                                                                              pathname_len);
               if (file_name) {
                 file_name->close_for_writing();
               }
@@ -945,8 +945,8 @@ void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf,
             /* A successful chdir. */
             const FBBCOMM_Serialized_posix_spawn_file_action_chdir *action_chdir =
                 reinterpret_cast<const FBBCOMM_Serialized_posix_spawn_file_action_chdir *>(action);
-            const char *path = action_chdir->get_path();
-            fork_child->handle_set_wd(path);
+            const char *pathname = action_chdir->get_pathname();
+            fork_child->handle_set_wd(pathname);
             break;
           }
           case FBBCOMM_TAG_posix_spawn_file_action_fchdir: {
@@ -1006,7 +1006,7 @@ void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf,
             int flags = action_open->get_flags();
             if (is_write(flags)) {
               const firebuild::FileName* file_name = proc->get_absolute(
-                  AT_FDCWD, action_open->get_path(), action_open->get_path_len());
+                  AT_FDCWD, action_open->get_pathname(), action_open->get_pathname_len());
               if (file_name) {
                 file_name->close_for_writing();
               }

--- a/src/firebuild/process.cc
+++ b/src/firebuild/process.cc
@@ -919,17 +919,17 @@ int Process::handle_rename(const int olddirfd, const char * const old_ar_name,
   return 0;
 }
 
-int Process::handle_symlink(const char * const old_ar_name,
+int Process::handle_symlink(const char * const target,
                             const int newdirfd, const char * const new_ar_name,
                             const int error) {
   TRACKX(FB_DEBUG_PROC, 1, 1, Process, this,
-         "old_ar_name=%s, newdirfd=%d, new_ar_name=%s, error=%d",
-         D(old_ar_name), newdirfd, D(new_ar_name), error);
+         "target=%s, newdirfd=%d, new_ar_name=%s, error=%d",
+         D(target), newdirfd, D(new_ar_name), error);
 
   if (!error) {
     exec_point()->disable_shortcutting_bubble_up(
         "Process created a symlink",
-        " ([" + d(newdirfd) + "]" + d(new_ar_name) + " -> " + d(old_ar_name) + ")");
+        " ([" + d(newdirfd) + "]" + d(new_ar_name) + " -> " + d(target) + ")");
     return -1;
   }
   return 0;

--- a/src/firebuild/process.h
+++ b/src/firebuild/process.h
@@ -426,13 +426,13 @@ class Process {
 
   /**
    * Handle symlink()
-   * @param old_ar_name old relative or absolute file name
+   * @param target relative or absolute target file name
    * @param newdirfd the newdirfd of symlinkat(), or AT_FDCWD
    * @param new_ar_name new relative or absolute file name
    * @param error error code
    * @return 0 on success, -1 on failure
    */
-  int handle_symlink(const char * const old_ar_name,
+  int handle_symlink(const char * const target,
                      const int newdirfd, const char * const new_ar_name,
                      const int error = 0);
 

--- a/src/firebuild/process_fbb_adaptor.cc
+++ b/src/firebuild/process_fbb_adaptor.cc
@@ -11,7 +11,7 @@
 namespace firebuild {
 int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_pre_open *msg) {
   return proc->handle_pre_open(msg->get_dirfd_with_fallback(AT_FDCWD),
-                               msg->get_file(), msg->get_file_len());
+                               msg->get_pathname(), msg->get_pathname_len());
 }
 
 int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_open *msg, int fd_conn,
@@ -19,7 +19,7 @@ int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_open *msg,
   const int dirfd = msg->get_dirfd_with_fallback(AT_FDCWD);
   int error = msg->get_error_no_with_fallback(0);
   int ret = msg->get_ret_with_fallback(-1);
-  return proc->handle_open(dirfd, msg->get_file(), msg->get_file_len(), msg->get_flags(),
+  return proc->handle_open(dirfd, msg->get_pathname(), msg->get_pathname_len(), msg->get_flags(),
                            msg->get_mode_with_fallback(0), ret, error, fd_conn, ack_num,
                            msg->get_pre_open_sent());
 }
@@ -29,7 +29,7 @@ int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_freopen *m
   int error = msg->get_error_no_with_fallback(0);
   int oldfd = msg->get_ret_with_fallback(-1);
   int ret = msg->get_ret_with_fallback(-1);
-  return proc->handle_freopen(msg->get_file(), msg->get_file_len(), msg->get_flags(),
+  return proc->handle_freopen(msg->get_pathname(), msg->get_pathname_len(), msg->get_flags(),
                               oldfd, ret, error, fd_conn, ack_num, msg->get_pre_open_sent());
 }
 
@@ -92,7 +92,7 @@ int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_stat *msg)
   const off_t st_size = msg->get_st_size_with_fallback(0);
   const int flags = msg->get_flags_with_fallback(0);
   const int error = msg->get_error_no_with_fallback(0);
-  return proc->handle_stat(dirfd, msg->get_filename(), msg->get_filename_len(),
+  return proc->handle_stat(dirfd, msg->get_pathname(), msg->get_pathname_len(),
                            flags, st_mode, st_size, error);
 }
 
@@ -110,7 +110,7 @@ int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_chmod *msg
   const mode_t mode = msg->get_mode();
   const int flags = msg->get_flags_with_fallback(0);
   const int error = msg->get_error_no_with_fallback(0);
-  return proc->handle_chmod(dirfd, msg->get_path(), msg->get_path_len(),
+  return proc->handle_chmod(dirfd, msg->get_pathname(), msg->get_pathname_len(),
                             mode, flags, error);
 }
 
@@ -163,7 +163,7 @@ int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_rename *ms
 int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_symlink *msg) {
   const int newdirfd = msg->get_newdirfd_with_fallback(AT_FDCWD);
   const int error = msg->get_error_no_with_fallback(0);
-  return proc->handle_symlink(msg->get_oldpath(), newdirfd, msg->get_newpath(), error);
+  return proc->handle_symlink(msg->get_target(), newdirfd, msg->get_newpath(), error);
 }
 
 int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_fcntl *msg) {
@@ -205,9 +205,9 @@ int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_umask *msg
 int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_chdir *msg) {
   const int error = msg->get_error_no_with_fallback(0);
   if (error == 0) {
-    proc->handle_set_wd(msg->get_dir(), msg->get_dir_len());
+    proc->handle_set_wd(msg->get_pathname(), msg->get_pathname_len());
   } else {
-    proc->handle_fail_wd(msg->get_dir());
+    proc->handle_fail_wd(msg->get_pathname());
   }
   return 0;
 }

--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -246,66 +246,66 @@ for gen in outputs:
 
 
 # Intercept vararg open() and friends
-generate("int", ["open", "open64"], "const char *file, int flags, ...",
+generate("int", ["open", "open64"], "const char *pathname, int flags, ...",
          tpl="open",
-         msg_skip_fields=["file"])
-generate("int", ["openat", "openat64"], "int dirfd, const char *file, int flags, ...",
+         msg_skip_fields=["pathname"])
+generate("int", ["openat", "openat64"], "int dirfd, const char *pathname, int flags, ...",
          tpl="open",
-         msg_skip_fields=["file"],
+         msg_skip_fields=["pathname"],
          msg="open")
 
 # Intercept open_2 variants
-generate("int", ["__open_2", "__open64_2"], "const char *file, int flags",
+generate("int", ["__open_2", "__open64_2"], "const char *pathname, int flags",
          tpl="open",
-         msg_skip_fields=["file"],
+         msg_skip_fields=["pathname"],
          msg="open")
-generate("int", ["__openat_2", "__openat64_2"], "int dirfd, const char *file, int flags",
+generate("int", ["__openat_2", "__openat64_2"], "int dirfd, const char *pathname, int flags",
          tpl="open",
-         msg_skip_fields=["file"],
+         msg_skip_fields=["pathname"],
          msg="open")
 
 # Intercept creat()
-generate("int", ["creat", "creat64"], "const char *file, mode_t mode",
+generate("int", ["creat", "creat64"], "const char *pathname, mode_t mode",
          tpl="open",
          before_lines=["const int flags = O_CREAT | O_WRONLY | O_TRUNC;"],
-         msg_skip_fields=["file"],
-         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(open, file);",
+         msg_skip_fields=["pathname"],
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(open, pathname);",
                          "fbbcomm_builder_open_set_flags(&ic_msg, flags);",
                          "fbbcomm_builder_open_set_pre_open_sent(&ic_msg, pre_open_sent);"],
          msg="open")
 
 # Intercept fopen
 # Note: confusingly open()'s and fopen()'s manual uses the word "mode" for something completely different.
-generate("FILE *", ["fopen", "fopen64"], "const char *file, const char *mode",
+generate("FILE *", ["fopen", "fopen64"], "const char *pathname, const char *mode",
          before_lines=["int open_flags = intercept_fopen_mode_to_open_flags_helper(mode);",
-                       "int pre_open_sent = i_am_intercepting && maybe_send_pre_open(AT_FDCWD, file, open_flags);"],
+                       "int pre_open_sent = i_am_intercepting && maybe_send_pre_open(AT_FDCWD, pathname, open_flags);"],
          after_lines=["int fd = safe_fileno(ret);",
                       "if (i_am_intercepting) clear_notify_on_read_write_state(fd);",
                       "assert(!voidp_set_contains(&popened_streams, ret));"],
          msg="open",
-         msg_skip_fields=["file", "mode"],
+         msg_skip_fields=["pathname", "mode"],
          msg_add_fields=["fbbcomm_builder_open_set_flags(&ic_msg, open_flags);",
                          "if (open_flags & O_CREAT) fbbcomm_builder_open_set_mode(&ic_msg, 0666);",
                          "if (success) fbbcomm_builder_open_set_ret(&ic_msg, fd);",
-                         "BUILDER_SET_ABSOLUTE_CANONICAL(open, file);",
+                         "BUILDER_SET_ABSOLUTE_CANONICAL(open, pathname);",
                          "fbbcomm_builder_open_set_pre_open_sent(&ic_msg, pre_open_sent);"],
-         ack_condition="success && !is_path_at_locations(file, &system_locations)")
+         ack_condition="success && !is_path_at_locations(pathname, &system_locations)")
 
 # Intercept freopen
-generate("FILE *", ["freopen", "freopen64"], "const char *file, const char *mode, FILE *stream",
+generate("FILE *", ["freopen", "freopen64"], "const char *pathname, const char *mode, FILE *stream",
          before_lines=["int open_flags = intercept_fopen_mode_to_open_flags_helper(mode);",
-                       "int pre_open_sent = i_am_intercepting && maybe_send_pre_open(AT_FDCWD, file, open_flags);",
+                       "int pre_open_sent = i_am_intercepting && maybe_send_pre_open(AT_FDCWD, pathname, open_flags);",
                        "int oldfd = safe_fileno(stream);",
                        "if (i_am_intercepting) clear_notify_on_read_write_state(oldfd);"],
          after_lines=["int newfd = safe_fileno(ret);",
                       "if (i_am_intercepting) clear_notify_on_read_write_state(newfd);"],
-         msg_skip_fields=["file", "mode", "stream"],
+         msg_skip_fields=["pathname", "mode", "stream"],
          msg_add_fields=["fbbcomm_builder_freopen_set_flags(&ic_msg, intercept_fopen_mode_to_open_flags_helper(mode));",
                          "if (oldfd >= 0) fbbcomm_builder_freopen_set_oldfd(&ic_msg, oldfd);",
                          "if (success) fbbcomm_builder_freopen_set_ret(&ic_msg, newfd);",
-                         "BUILDER_SET_ABSOLUTE_CANONICAL(freopen, file);",
+                         "BUILDER_SET_ABSOLUTE_CANONICAL(freopen, pathname);",
                          "fbbcomm_builder_freopen_set_pre_open_sent(&ic_msg, pre_open_sent);"],
-         ack_condition="success && !is_path_at_locations(file, &system_locations)")
+         ack_condition="success && !is_path_at_locations(pathname, &system_locations)")
 
 # High level stream operation only
 generate("FILE *", "fdopen", "int fd, const char *mode",
@@ -368,14 +368,14 @@ generate("int", "fcloseall", "",
          after_lines=["voidp_set_clear(&popened_streams);"])
 
 # Intercept opendir, closedir (no need to intercept fdopendir)
-generate("DIR *", "opendir", "const char *file",
+generate("DIR *", "opendir", "const char *pathname",
          msg="open",
-         msg_skip_fields=["file"],
+         msg_skip_fields=["pathname"],
          msg_add_fields=["fbbcomm_builder_open_set_flags(&ic_msg, O_RDONLY | O_CLOEXEC | O_DIRECTORY);",
                          "if (success) fbbcomm_builder_open_set_ret(&ic_msg, IC_ORIG(dirfd)(ret));",
-                         "BUILDER_SET_ABSOLUTE_CANONICAL(open, file);",
+                         "BUILDER_SET_ABSOLUTE_CANONICAL(open, pathname);",
                          "fbbcomm_builder_open_set_pre_open_sent(&ic_msg, false);"],
-         ack_condition="success && !is_path_at_locations(file, &system_locations)")
+         ack_condition="success && !is_path_at_locations(pathname, &system_locations)")
 generate("int", "closedir", "DIR *dirp",
          before_lines=["int fd = safe_dirfd(dirp); /* save it here, we can't do dirfd() after the closedir() */"],
          msg="close",
@@ -894,10 +894,10 @@ for v in ['', 'v']:
     skip(c1 + v + "asprintf" + c2)
 
 # Intercept chdir and fchdir
-generate("int", "chdir", "const char *dir",
-         msg_skip_fields=["dir"],
-         # Don't make dir absolute, since the macro would calculate it after calling chdir
-         msg_add_fields=["BUILDER_SET_CANONICAL(chdir, dir);",
+generate("int", "chdir", "const char *pathname",
+         msg_skip_fields=["pathname"],
+         # Don't make pathname absolute, since the macro would calculate it after calling chdir
+         msg_add_fields=["BUILDER_SET_CANONICAL(chdir, pathname);",
                          "if (success) {",
                          "  char* getcwd_ret = IC_ORIG(getcwd)(ic_cwd, IC_PATH_BUFSIZE);",
                          "  (void) getcwd_ret;",
@@ -911,33 +911,33 @@ generate("int", "fchdir", "int fd",
                       "}"])
 
 # Intercept the chmod family
-generate("int", "chmod", "const char *path, mode_t mode",
-         msg_skip_fields=["path"],
-         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(chmod, path);"])
-generate("int", "lchmod", "const char *path, mode_t mode",
+generate("int", "chmod", "const char *pathname, mode_t mode",
+         msg_skip_fields=["pathname"],
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(chmod, pathname);"])
+generate("int", "lchmod", "const char *pathname, mode_t mode",
          msg="chmod",
-         msg_skip_fields=["path"],
-         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(chmod, path);",
+         msg_skip_fields=["pathname"],
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(chmod, pathname);",
                          "fbbcomm_builder_chmod_set_flags(&ic_msg, AT_SYMLINK_NOFOLLOW);"])
-generate("int", "fchmodat", "int dirfd, const char *path, mode_t mode, int flags",
+generate("int", "fchmodat", "int dirfd, const char *pathname, mode_t mode, int flags",
          msg="chmod",
-         msg_skip_fields=["path"],
-         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(chmod, dirfd, path);"])
+         msg_skip_fields=["pathname"],
+         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(chmod, dirfd, pathname);"])
 generate("int", "fchmod", "int fd, mode_t mode")
 
 # Intercept the chown family
-generate("int", "chown", "const char *path, uid_t owner, gid_t group",
-         msg_skip_fields=["path"],
-         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(chown, path);"])
-generate("int", "lchown", "const char *path, uid_t owner, gid_t group",
+generate("int", "chown", "const char *pathname, uid_t owner, gid_t group",
+         msg_skip_fields=["pathname"],
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(chown, pathname);"])
+generate("int", "lchown", "const char *pathname, uid_t owner, gid_t group",
          msg="chown",
-         msg_skip_fields=["path"],
-         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(chown, path);",
+         msg_skip_fields=["pathname"],
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(chown, pathname);",
                          "fbbcomm_builder_chown_set_flags(&ic_msg, AT_SYMLINK_NOFOLLOW);"])
-generate("int", "fchownat", "int dirfd, const char *path, uid_t owner, gid_t group, int flags",
+generate("int", "fchownat", "int dirfd, const char *pathname, uid_t owner, gid_t group, int flags",
          msg="chown",
-         msg_skip_fields=["path"],
-         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(chown, dirfd, path);"])
+         msg_skip_fields=["pathname"],
+         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(chown, dirfd, pathname);"])
 generate("int", "fchown", "int fd, uid_t owner, gid_t group")
 
 # Intercept the link, symlink and readlink families
@@ -950,66 +950,66 @@ generate("int", "linkat", "int olddirfd, const char *oldpath, int newdirfd, cons
          msg_add_fields = ["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(link, olddirfd, oldpath);",
                            "BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(link, newdirfd, newpath);"],
          msg="link")
-generate("int", "symlink", "const char *oldpath, const char *newpath",
+generate("int", "symlink", "const char *target, const char *newpath",
          msg_skip_fields = ["newpath"],
          msg_add_fields = ["BUILDER_SET_ABSOLUTE_CANONICAL(symlink, newpath);"])
-generate("int", "symlinkat", "const char *oldpath, int newdirfd, const char *newpath",
+generate("int", "symlinkat", "const char *target, int newdirfd, const char *newpath",
          msg_skip_fields = ["newpath"],
          msg_add_fields = ["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(symlink, newdirfd, newpath);"],
          msg="symlink")
 
-generate("ssize_t", "readlink", "const char *path, char *buf, size_t bufsiz",
+generate("ssize_t", "readlink", "const char *pathname, char *buf, size_t bufsiz",
          tpl="readlink",
-         msg_skip_fields=["path", "buf"],
-         msg_add_fields = ["BUILDER_SET_ABSOLUTE_CANONICAL(readlink, path);"])
-generate("ssize_t", "__readlink_chk", "const char *path, char *buf, size_t bufsiz, size_t fortify_size",
-         tpl="readlink",
-         msg="readlink",
-         msg_skip_fields=["path", "buf", "fortify_size"],
-         msg_add_fields = ["BUILDER_SET_ABSOLUTE_CANONICAL(readlink, path);"])
-generate("ssize_t", "readlinkat", "int dirfd, const char *path, char *buf, size_t bufsiz",
+         msg_skip_fields=["pathname", "buf"],
+         msg_add_fields = ["BUILDER_SET_ABSOLUTE_CANONICAL(readlink, pathname);"])
+generate("ssize_t", "__readlink_chk", "const char *pathname, char *buf, size_t bufsiz, size_t fortify_size",
          tpl="readlink",
          msg="readlink",
-         msg_skip_fields=["path", "buf"],
-         msg_add_fields = ["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(readlink, dirfd, path);"])
-generate("ssize_t", "__readlinkat_chk", "int dirfd, const char *path, char *buf, size_t bufsiz, size_t fortify_size",
+         msg_skip_fields=["pathname", "buf", "fortify_size"],
+         msg_add_fields = ["BUILDER_SET_ABSOLUTE_CANONICAL(readlink, pathname);"])
+generate("ssize_t", "readlinkat", "int dirfd, const char *pathname, char *buf, size_t bufsiz",
          tpl="readlink",
          msg="readlink",
-         msg_skip_fields=["path", "buf", "fortify_size"],
-         msg_add_fields = ["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(readlink, dirfd, path);"])
+         msg_skip_fields=["pathname", "buf"],
+         msg_add_fields = ["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(readlink, dirfd, pathname);"])
+generate("ssize_t", "__readlinkat_chk", "int dirfd, const char *pathname, char *buf, size_t bufsiz, size_t fortify_size",
+         tpl="readlink",
+         msg="readlink",
+         msg_skip_fields=["pathname", "buf", "fortify_size"],
+         msg_add_fields = ["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(readlink, dirfd, pathname);"])
 # FIXME realpath
 
 # Intercept the stat family
 # mysterious hacks prior to glibc 2.33
-generate("int", "__xstat", "int ver, const char *filename, struct stat *stat_buf",
+generate("int", "__xstat", "int ver, const char *pathname, struct stat *stat_buf",
          msg="stat",
-         msg_skip_fields=["ver", "filename", "stat_buf"],
-         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(stat, filename);",
+         msg_skip_fields=["ver", "pathname", "stat_buf"],
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(stat, pathname);",
                          "if (success) {",
                          "  fbbcomm_builder_stat_set_st_mode(&ic_msg, stat_buf->st_mode);",
                          "  fbbcomm_builder_stat_set_st_size(&ic_msg, stat_buf->st_size);",
                          "}"])
-generate("int", "__xstat64", "int ver, const char *filename, struct stat64 *stat_buf",
+generate("int", "__xstat64", "int ver, const char *pathname, struct stat64 *stat_buf",
          msg="stat",
-         msg_skip_fields=["ver", "filename", "stat_buf"],
-         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(stat, filename);",
+         msg_skip_fields=["ver", "pathname", "stat_buf"],
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(stat, pathname);",
                          "if (success) {",
                          "  fbbcomm_builder_stat_set_st_mode(&ic_msg, stat_buf->st_mode);",
                          "  fbbcomm_builder_stat_set_st_size(&ic_msg, stat_buf->st_size);",
                          "}"])
-generate("int", "__lxstat", "int ver, const char *filename, struct stat *stat_buf",
+generate("int", "__lxstat", "int ver, const char *pathname, struct stat *stat_buf",
          msg="stat",
-         msg_skip_fields=["ver", "filename", "stat_buf"],
-         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(stat, filename);",
+         msg_skip_fields=["ver", "pathname", "stat_buf"],
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(stat, pathname);",
                          "fbbcomm_builder_stat_set_flags(&ic_msg, AT_SYMLINK_NOFOLLOW);",
                          "if (success) {",
                          "  fbbcomm_builder_stat_set_st_mode(&ic_msg, stat_buf->st_mode);",
                          "  fbbcomm_builder_stat_set_st_size(&ic_msg, stat_buf->st_size);",
                          "}"])
-generate("int", "__lxstat64", "int ver, const char *filename, struct stat64 *stat_buf",
+generate("int", "__lxstat64", "int ver, const char *pathname, struct stat64 *stat_buf",
          msg="stat",
-         msg_skip_fields=["ver", "filename", "stat_buf"],
-         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(stat, filename);",
+         msg_skip_fields=["ver", "pathname", "stat_buf"],
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(stat, pathname);",
                          "fbbcomm_builder_stat_set_flags(&ic_msg, AT_SYMLINK_NOFOLLOW);",
                          "if (success) {",
                          "  fbbcomm_builder_stat_set_st_mode(&ic_msg, stat_buf->st_mode);",
@@ -1029,52 +1029,52 @@ generate("int", "__fxstat64", "int ver, int fd, struct stat64 *stat_buf",
                          "  fbbcomm_builder_fstat_set_st_mode(&ic_msg, stat_buf->st_mode);",
                          "  fbbcomm_builder_fstat_set_st_size(&ic_msg, stat_buf->st_size);",
                          "}"])
-generate("int", "__fxstatat", "int ver, int dirfd, const char *filename, struct stat *stat_buf, int flags",
+generate("int", "__fxstatat", "int ver, int dirfd, const char *pathname, struct stat *stat_buf, int flags",
          msg="stat",
-         msg_skip_fields=["ver", "filename", "stat_buf"],
-         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(stat, dirfd, filename);",
+         msg_skip_fields=["ver", "pathname", "stat_buf"],
+         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(stat, dirfd, pathname);",
                          "if (success) {",
                          "  fbbcomm_builder_stat_set_st_mode(&ic_msg, stat_buf->st_mode);",
                          "  fbbcomm_builder_stat_set_st_size(&ic_msg, stat_buf->st_size);",
                          "}"])
-generate("int", "__fxstatat64", "int ver, int dirfd, const char *filename, struct stat64 *stat_buf, int flags",
+generate("int", "__fxstatat64", "int ver, int dirfd, const char *pathname, struct stat64 *stat_buf, int flags",
          msg="stat",
-         msg_skip_fields=["ver", "filename", "stat_buf"],
-         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(stat, dirfd, filename);",
+         msg_skip_fields=["ver", "pathname", "stat_buf"],
+         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(stat, dirfd, pathname);",
                          "if (success) {",
                          "  fbbcomm_builder_stat_set_st_mode(&ic_msg, stat_buf->st_mode);",
                          "  fbbcomm_builder_stat_set_st_size(&ic_msg, stat_buf->st_size);",
                          "}"])
 # cleaned up beginning with glibc 2.33
-generate("int", "stat", "const char *filename, struct stat *stat_buf",
+generate("int", "stat", "const char *pathname, struct stat *stat_buf",
          msg="stat",
-         msg_skip_fields=["filename", "stat_buf"],
-         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(stat, filename);",
+         msg_skip_fields=["pathname", "stat_buf"],
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(stat, pathname);",
                          "if (success) {",
                          "  fbbcomm_builder_stat_set_st_mode(&ic_msg, stat_buf->st_mode);",
                          "  fbbcomm_builder_stat_set_st_size(&ic_msg, stat_buf->st_size);",
                          "}"])
-generate("int", "stat64", "const char *filename, struct stat64 *stat_buf",
+generate("int", "stat64", "const char *pathname, struct stat64 *stat_buf",
          msg="stat",
-         msg_skip_fields=["filename", "stat_buf"],
-         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(stat, filename);",
+         msg_skip_fields=["pathname", "stat_buf"],
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(stat, pathname);",
                          "if (success) {",
                          "  fbbcomm_builder_stat_set_st_mode(&ic_msg, stat_buf->st_mode);",
                          "  fbbcomm_builder_stat_set_st_size(&ic_msg, stat_buf->st_size);",
                          "}"])
-generate("int", "lstat", "const char *filename, struct stat *stat_buf",
+generate("int", "lstat", "const char *pathname, struct stat *stat_buf",
          msg="stat",
-         msg_skip_fields=["filename", "stat_buf"],
-         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(stat, filename);",
+         msg_skip_fields=["pathname", "stat_buf"],
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(stat, pathname);",
                          "fbbcomm_builder_stat_set_flags(&ic_msg, AT_SYMLINK_NOFOLLOW);",
                          "if (success) {",
                          "  fbbcomm_builder_stat_set_st_mode(&ic_msg, stat_buf->st_mode);",
                          "  fbbcomm_builder_stat_set_st_size(&ic_msg, stat_buf->st_size);",
                          "}"])
-generate("int", "lstat64", "const char *filename, struct stat64 *stat_buf",
+generate("int", "lstat64", "const char *pathname, struct stat64 *stat_buf",
          msg="stat",
-         msg_skip_fields=["filename", "stat_buf"],
-         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(stat, filename);",
+         msg_skip_fields=["pathname", "stat_buf"],
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(stat, pathname);",
                          "fbbcomm_builder_stat_set_flags(&ic_msg, AT_SYMLINK_NOFOLLOW);",
                          "if (success) {",
                          "  fbbcomm_builder_stat_set_st_mode(&ic_msg, stat_buf->st_mode);",
@@ -1094,30 +1094,30 @@ generate("int", "fstat64", "int fd, struct stat64 *stat_buf",
                          "  fbbcomm_builder_fstat_set_st_mode(&ic_msg, stat_buf->st_mode);",
                          "  fbbcomm_builder_fstat_set_st_size(&ic_msg, stat_buf->st_size);",
                          "}"])
-generate("int", "fstatat", "int dirfd, const char *filename, struct stat *stat_buf, int flags",
+generate("int", "fstatat", "int dirfd, const char *pathname, struct stat *stat_buf, int flags",
          msg="stat",
-         msg_skip_fields=["filename", "stat_buf"],
-         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(stat, dirfd, filename);",
+         msg_skip_fields=["pathname", "stat_buf"],
+         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(stat, dirfd, pathname);",
                          "if (success) {",
                          "  fbbcomm_builder_stat_set_st_mode(&ic_msg, stat_buf->st_mode);",
                          "  fbbcomm_builder_stat_set_st_size(&ic_msg, stat_buf->st_size);",
                          "}"])
-generate("int", "fstatat64", "int dirfd, const char *filename, struct stat64 *stat_buf, int flags",
+generate("int", "fstatat64", "int dirfd, const char *pathname, struct stat64 *stat_buf, int flags",
          msg="stat",
-         msg_skip_fields=["filename", "stat_buf"],
-         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(stat, dirfd, filename);",
+         msg_skip_fields=["pathname", "stat_buf"],
+         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(stat, dirfd, pathname);",
                          "if (success) {",
                          "  fbbcomm_builder_stat_set_st_mode(&ic_msg, stat_buf->st_mode);",
                          "  fbbcomm_builder_stat_set_st_size(&ic_msg, stat_buf->st_size);",
                          "}"])
 # since glibc 2.28
-generate("int", "statx", "int dirfd, const char *filename, int flags, unsigned int mask, struct statx *statx_buf",
+generate("int", "statx", "int dirfd, const char *pathname, int flags, unsigned int mask, struct statx *statx_buf",
          # TODO(rbalint) have separate statx() message with mask also sent
          msg="stat",
          # Always query type and mode to let the supervisor have valid stx_mode
          before_lines=["mask |= STATX_TYPE | STATX_MODE | STATX_SIZE;"],
-         msg_skip_fields=["filename", "mask", "statx_buf"],
-         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(stat, dirfd, filename);",
+         msg_skip_fields=["pathname", "mask", "statx_buf"],
+         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(stat, dirfd, pathname);",
                          "if (success) {",
                          "  fbbcomm_builder_stat_set_st_mode(&ic_msg, statx_buf->stx_mode);",
                          "  fbbcomm_builder_stat_set_st_size(&ic_msg, statx_buf->stx_size);",
@@ -1189,30 +1189,30 @@ generate("int", "faccessat", "int dirfd, const char *pathname, int mode, int fla
          msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(faccessat, dirfd, pathname);"])
 
 # Intercept the (l)utime family
-generate("int", "utime", "const char *file, const struct utimbuf *times",
-         msg_skip_fields=["file", "times"],
-         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(utime, file);",
+generate("int", "utime", "const char *pathname, const struct utimbuf *times",
+         msg_skip_fields=["pathname", "times"],
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(utime, pathname);",
                          "fbbcomm_builder_utime_set_all_utime_now(&ic_msg, times == NULL);"])
-generate("int", "utimes", "const char *file, const struct timeval times[2]",
+generate("int", "utimes", "const char *pathname, const struct timeval times[2]",
          msg="utime",
-         msg_skip_fields=["file", "times"],
-         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(utime, file);",
+         msg_skip_fields=["pathname", "times"],
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(utime, pathname);",
                          "fbbcomm_builder_utime_set_all_utime_now(&ic_msg, times == NULL);"])
-generate("int", "lutimes", "const char *file, const struct timeval times[2]",
+generate("int", "lutimes", "const char *pathname, const struct timeval times[2]",
          msg="utime",
-         msg_skip_fields=["file", "times"],
-         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(utime, file);",
+         msg_skip_fields=["pathname", "times"],
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(utime, pathname);",
                          "fbbcomm_builder_utime_set_all_utime_now(&ic_msg, times == NULL);",
                          "fbbcomm_builder_utime_set_flags(&ic_msg, AT_SYMLINK_NOFOLLOW);"])
-generate("int", "utimensat", "int dirfd, const char *file, const struct timespec times[2], int flags",
+generate("int", "utimensat", "int dirfd, const char *pathname, const struct timespec times[2], int flags",
          msg="utime",
-         msg_skip_fields=["file", "times"],
-         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(utime, dirfd, file);",
+         msg_skip_fields=["pathname", "times"],
+         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(utime, dirfd, pathname);",
                          "fbbcomm_builder_utime_set_all_utime_now(&ic_msg, times == NULL || (times[0].tv_nsec == UTIME_NOW && times[1].tv_nsec == UTIME_NOW));"])
-generate("int", "futimesat", "int dirfd, const char *file, const struct timeval times[2]",
+generate("int", "futimesat", "int dirfd, const char *pathname, const struct timeval times[2]",
          msg="utime",
-         msg_skip_fields=["file", "times"],
-         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(utime, dirfd, file);",
+         msg_skip_fields=["pathname", "times"],
+         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(utime, dirfd, pathname);",
                          "fbbcomm_builder_utime_set_all_utime_now(&ic_msg, times == NULL);"])
 
 # Intercept the futime family
@@ -1263,56 +1263,56 @@ generate("int", "pipe2", "int pipefd[2], int flags",
                          "}"])
 
 # Intercept the truncate family
-generate("int", "truncate", "const char *path, off_t len",
+generate("int", "truncate", "const char *pathname, off_t len",
          msg_skip_fields=["path"],
-         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(truncate, path);"])
-generate("int", "truncate64", "const char *path, off64_t len",
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(truncate, pathname);"])
+generate("int", "truncate64", "const char *pathname, off64_t len",
          msg="truncate",
          msg_skip_fields=["path"],
-         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(truncate, path);"])
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(truncate, pathname);"])
 generate("int", "ftruncate", "int fd, off_t len")
 generate("int", "ftruncate64", "int fd, off64_t len",
          msg="ftruncate")
 
 # Intercept the mkstemp family
-# Note: these update the file template in place.
-generate("int", "mkstemp", "char *file",
+# Note: these update the pathname template in place.
+generate("int", "mkstemp", "char *pathname",
          send_msg_on_error=False,
          msg="open",
          msg_skip_fields=["path"],
          msg_add_fields=["fbbcomm_builder_open_set_flags(&ic_msg, O_RDWR | O_CREAT | O_EXCL);",
                          "fbbcomm_builder_open_set_mode(&ic_msg, 0600);",
-                         "BUILDER_SET_ABSOLUTE_CANONICAL(open, file);",
+                         "BUILDER_SET_ABSOLUTE_CANONICAL(open, pathname);",
                          "fbbcomm_builder_open_set_pre_open_sent(&ic_msg, false);"],
          send_ret_on_success=True,
          ack_condition="true")
-generate("int", "mkostemp", "char *file, int flags",
+generate("int", "mkostemp", "char *pathname, int flags",
          send_msg_on_error=False,
          msg="open",
-         msg_skip_fields=["file", "flags"],
+         msg_skip_fields=["pathname", "flags"],
          msg_add_fields=["fbbcomm_builder_open_set_flags(&ic_msg, O_RDWR | O_CREAT | O_EXCL | (flags & (O_APPEND | O_CLOEXEC | O_SYNC)));",
                          "fbbcomm_builder_open_set_mode(&ic_msg, 0600);",
-                         "BUILDER_SET_ABSOLUTE_CANONICAL(open, file);",
+                         "BUILDER_SET_ABSOLUTE_CANONICAL(open, pathname);",
                          "fbbcomm_builder_open_set_pre_open_sent(&ic_msg, false);"],
          send_ret_on_success=True,
          ack_condition="true")
-generate("int", "mkstemps", "char *file, int suffixlen",
+generate("int", "mkstemps", "char *pathname, int suffixlen",
          send_msg_on_error=False,
          msg="open",
-         msg_skip_fields=["file", "suffixlen"],
+         msg_skip_fields=["pathname", "suffixlen"],
          msg_add_fields=["fbbcomm_builder_open_set_flags(&ic_msg, O_RDWR | O_CREAT | O_EXCL);",
                          "fbbcomm_builder_open_set_mode(&ic_msg, 0600);",
-                         "BUILDER_SET_ABSOLUTE_CANONICAL(open, file);",
+                         "BUILDER_SET_ABSOLUTE_CANONICAL(open, pathname);",
                          "fbbcomm_builder_open_set_pre_open_sent(&ic_msg, false);"],
          send_ret_on_success=True,
          ack_condition="true")
-generate("int", "mkostemps", "char *file, int suffixlen, int flags",
+generate("int", "mkostemps", "char *pathname, int suffixlen, int flags",
          send_msg_on_error=False,
          msg="open",
-         msg_skip_fields=["file", "suffixlen", "flags"],
+         msg_skip_fields=["pathname", "suffixlen", "flags"],
          msg_add_fields=["fbbcomm_builder_open_set_flags(&ic_msg, O_RDWR | O_CREAT | O_EXCL | (flags & (O_APPEND | O_CLOEXEC | O_SYNC)));",
                          "fbbcomm_builder_open_set_mode(&ic_msg, 0600);",
-                         "BUILDER_SET_ABSOLUTE_CANONICAL(open, file);",
+                         "BUILDER_SET_ABSOLUTE_CANONICAL(open, pathname);",
                          "fbbcomm_builder_open_set_pre_open_sent(&ic_msg, false);"],
          send_ret_on_success=True,
          ack_condition="true")
@@ -1427,7 +1427,7 @@ generate("int", "posix_spawnp", "pid_t *pid, const char *file, " +
 generate("int", ["posix_spawn_file_actions_init", "posix_spawn_file_actions_destroy"], "posix_spawn_file_actions_t *file_actions",
          tpl="posix_spawn_file_actions",
          success="ret == 0")
-generate("int", "posix_spawn_file_actions_addopen", "posix_spawn_file_actions_t *file_actions, int fd, const char *path, int flags, mode_t mode",
+generate("int", "posix_spawn_file_actions_addopen", "posix_spawn_file_actions_t *file_actions, int fd, const char *pathname, int flags, mode_t mode",
          tpl="posix_spawn_file_actions",
          success="ret == 0")
 generate("int", "posix_spawn_file_actions_addclose", "posix_spawn_file_actions_t *file_actions, int fd",
@@ -1439,7 +1439,7 @@ generate("int", "posix_spawn_file_actions_addclosefrom_np", "posix_spawn_file_ac
 generate("int", "posix_spawn_file_actions_adddup2", "posix_spawn_file_actions_t *file_actions, int oldfd, int newfd",
          tpl="posix_spawn_file_actions",
          success="ret == 0")
-generate("int", "posix_spawn_file_actions_addchdir_np", "posix_spawn_file_actions_t *file_actions, const char *path",
+generate("int", "posix_spawn_file_actions_addchdir_np", "posix_spawn_file_actions_t *file_actions, const char *pathname",
          tpl="posix_spawn_file_actions",
          success="ret == 0")
 generate("int", "posix_spawn_file_actions_addfchdir_np", "posix_spawn_file_actions_t *file_actions, int fd",

--- a/src/interceptor/intercept.h
+++ b/src/interceptor/intercept.h
@@ -99,8 +99,8 @@ void fb_fbbcomm_send_msg_and_check_ack(const void /*FBBCOMM_Builder*/ *ic_msg, i
  * Send pre_open message to supervisor if it is needed.
  * @return if message has been sent
  */
-bool maybe_send_pre_open(int dirfd, const char* file, int flags);
-bool maybe_send_pre_open_without_ack_request(int dirfd, const char* file, int flags);
+bool maybe_send_pre_open(int dirfd, const char* pathname, int flags);
+bool maybe_send_pre_open_without_ack_request(int dirfd, const char* pathname, int flags);
 
 /** Connection string to supervisor */
 extern char fb_conn_string[IC_PATH_BUFSIZE];
@@ -122,11 +122,11 @@ extern bool intercepting_enabled;
 extern void psfa_init(const posix_spawn_file_actions_t *p);
 extern void psfa_destroy(const posix_spawn_file_actions_t *p);
 extern void psfa_addopen(const posix_spawn_file_actions_t *p, int fd,
-                         const char *path, int flags, mode_t mode);
+                         const char *pathname, int flags, mode_t mode);
 extern void psfa_addclose(const posix_spawn_file_actions_t *p, int fd);
 extern void psfa_addclosefrom_np(const posix_spawn_file_actions_t *p, int fd);
 extern void psfa_adddup2(const posix_spawn_file_actions_t *p, int oldfd, int newfd);
-extern void psfa_addchdir_np(const posix_spawn_file_actions_t *p, const char *path);
+extern void psfa_addchdir_np(const posix_spawn_file_actions_t *p, const char *pathname);
 extern void psfa_addfchdir_np(const posix_spawn_file_actions_t *p, int fd);
 extern voidp_array *psfa_find(const posix_spawn_file_actions_t *p);
 

--- a/src/interceptor/tpl_open.c
+++ b/src/interceptor/tpl_open.c
@@ -13,15 +13,15 @@
 ###     set msg_add_fields = []
 ###   endif
 ###   if "dirfd" in sig_str
-###     do msg_add_fields.append("BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(" + msg + ", dirfd, file);")
+###     do msg_add_fields.append("BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(" + msg + ", dirfd, pathname);")
 ###   else
-###     do msg_add_fields.append("BUILDER_SET_ABSOLUTE_CANONICAL(" + msg + ", file);")
+###     do msg_add_fields.append("BUILDER_SET_ABSOLUTE_CANONICAL(" + msg + ", pathname);")
 ###   endif
 ###   do msg_add_fields.append("fbbcomm_builder_" + msg + "_set_pre_open_sent(&ic_msg, pre_open_sent);")
 ### endif
 ### set after_lines = ["if (i_am_intercepting) clear_notify_on_read_write_state(ret);"]
 ### set send_ret_on_success=True
-### set ack_condition = "success && !is_path_at_locations(file, &system_locations)"
+### set ack_condition = "success && !is_path_at_locations(pathname, &system_locations)"
 
 ### block before
 {{ super() }}
@@ -31,7 +31,7 @@
     mode = va_arg(ap, mode_t);
   }
 ###   endif
-  const int pre_open_sent = i_am_intercepting && maybe_send_pre_open(AT_FDCWD, file, flags);
+  const int pre_open_sent = i_am_intercepting && maybe_send_pre_open(AT_FDCWD, pathname, flags);
 ### endblock before
 
 ### block call_orig

--- a/src/interceptor/tpl_readlink.c
+++ b/src/interceptor/tpl_readlink.c
@@ -14,11 +14,11 @@
     if (ret >= 0 && (size_t)labs(ret) <= bufsiz) {
       len = ret;
     }
-    char ret_path[len + 1];
+    char ret_target[len + 1];
     if (len > 0) {
-      memcpy(ret_path, buf, len);
-      ret_path[len] = '\0';
-      /* Returned path is assumed to be canonical.*/
-      fbbcomm_builder_{{ msg }}_set_ret_path(&ic_msg, ret_path);
+      memcpy(ret_target, buf, len);
+      ret_target[len] = '\0';
+      /* Returned path is a raw string, not to be resolved. */
+      fbbcomm_builder_{{ msg }}_set_ret_target(&ic_msg, ret_target);
     }
 ### endblock set_fields


### PR DESCRIPTION
To be consistent with the majority of the manual pages, prefer
"pathname" when it's yet to be resolved against cwd or a dirfd, but is
not to be searched along some path.

Also, use "target" for a symbolic link's target pathname.

Improves #850.