### PR TITLE
interceptor: Try to set argc and argv using libfirebuild's constructor

### DIFF
--- a/src/interceptor/env.c
+++ b/src/interceptor/env.c
@@ -21,26 +21,6 @@
 #define LD_PRELOAD              "LD_PRELOAD"
 #define LIBFIREBUILD_SO_LEN     ((int) strlen(LIBFIREBUILD_SO))
 
-void get_argv_env(char *** argv, char ***env) {
-  char* arg = *(__environ - 2);
-  unsigned long int argc_guess = 0;
-
-  /* argv is NULL terminated */
-  assert(*(__environ - 1) == NULL);
-  /* walk back on argv[] to find the first value matching the counted argument number */
-  while (argc_guess != (unsigned long int)arg) {
-    argc_guess++;
-    arg = *(__environ - 2 - argc_guess);
-  }
-
-  *argv = __environ - 1 - argc_guess;
-  *env = __environ;
-}
-
-// TODO(rbalint) for valgrind
-// void free_arc_argv_env()
-
-
 /* Like getenv(), but from a custom environment array */
 static char *getenv_from(char **env, const char *name) {
   int name_len = strlen(name);

--- a/src/interceptor/env.h
+++ b/src/interceptor/env.h
@@ -7,13 +7,6 @@
 
 #include <stdbool.h>
 
-
-/**
- * Get process's arguments and environment
- */
-void get_argv_env(char *** argv, char ***env);
-
-
 /**
  * Whether the environment needs any fixup at all.
  */

--- a/src/interceptor/intercept.h
+++ b/src/interceptor/intercept.h
@@ -332,7 +332,7 @@ inline void thread_signal_danger_zone_leave() {
 void grab_global_lock(bool *i_locked, const char * const function_name);
 void release_global_lock();
 
-extern void fb_ic_load() __attribute__((constructor));
+extern void fb_ic_load();
 extern void handle_exit();
 void *pthread_start_routine_wrapper(void *routine_and_arg);
 extern int __libc_start_main(int (*main)(int, char **, char **),


### PR DESCRIPTION
This is expected to work with GCC and clang and to be more reliable than
guessing the values based on __environ pointer, which is kept as a fallback.

Fixes #915.