### PR TITLE
supervisor: Handle unlink() returning ENOENT

### DIFF
--- a/src/firebuild/process.cc
+++ b/src/firebuild/process.cc
@@ -385,6 +385,12 @@ int Process::handle_unlink(const int dirfd, const char * const ar_name, const si
           "Could not register the unlink or rmdir", *name);
       return -1;
     }
+  } else if (error == ENOENT) {
+    FileUsageUpdate update(name, NOTEXIST);
+    if (!exec_point()->register_file_usage_update(name, update)) {
+      exec_point()->disable_shortcutting_bubble_up("Could not register the unlink or rmdir", *name);
+      return -1;
+    }
   }
 
   return 0;


### PR DESCRIPTION
Register file for which unlink() gave ENOENT error as a missing file.

This prevents disabling shortcutting gfortran and possibly other processes
which try to unlink files before creating them.