### PR TITLE
interceptor: Prefer using the IC_ORIG macro

### DIFF
--- a/src/interceptor/intercept.c
+++ b/src/interceptor/intercept.c
@@ -874,8 +874,8 @@ static void fb_ic_init() {
   fbbcomm_builder_scproc_query_set_cwd(&ic_msg, ic_cwd);
   fbbcomm_builder_scproc_query_set_arg_with_count(&ic_msg, (const char **) ic_argv, ic_argc);
 
-  mode_t initial_umask = ic_orig_umask(0077);
-  ic_orig_umask(initial_umask);
+  mode_t initial_umask = IC_ORIG(umask)(0077);
+  IC_ORIG(umask)(initial_umask);
   fbbcomm_builder_scproc_query_set_umask(&ic_msg, initial_umask);
 
   /* make a sorted and filtered copy of env */

--- a/src/interceptor/tpl_close_range.c
+++ b/src/interceptor/tpl_close_range.c
@@ -22,20 +22,20 @@
   const unsigned int u_fb_sv_conn = (unsigned int)fb_sv_conn;
   if (first > u_fb_sv_conn || last < u_fb_sv_conn) {
     /* Just go ahead. */
-    ret = ic_orig_close_range(first, last, flags);
+    ret = IC_ORIG(close_range)(first, last, flags);
   } else if (first == u_fb_sv_conn && last == u_fb_sv_conn) {
     /* Wishing to close only fb_sv_conn. Just pretend it succeeded. */
     ret = 0;
   } else if (first == u_fb_sv_conn) {
     /* Need to skip the first fd. */
-    ret = ic_orig_close_range(first + 1, last, flags);
+    ret = IC_ORIG(close_range)(first + 1, last, flags);
   } else if (last == u_fb_sv_conn) {
     /* Need to skip the last fd. */
-    ret = ic_orig_close_range(first, last - 1, flags);
+    ret = IC_ORIG(close_range)(first, last - 1, flags);
   } else {
     /* Need to leave a hole in the range. */
-    int ret1 = ic_orig_close_range(first, u_fb_sv_conn - 1, 0);
-    int ret2 = ic_orig_close_range(u_fb_sv_conn + 1, last, 0);
+    int ret1 = IC_ORIG(close_range)(first, u_fb_sv_conn - 1, 0);
+    int ret2 = IC_ORIG(close_range)(u_fb_sv_conn + 1, last, 0);
     ret = (ret1 == 0 && ret2 == 0) ? 0 : -1;
   }
 ### endblock call_orig

--- a/src/interceptor/tpl_closefrom.c
+++ b/src/interceptor/tpl_closefrom.c
@@ -21,13 +21,13 @@
 
   if (lowfd > fb_sv_conn) {
     /* Just go ahead. */
-    ic_orig_closefrom(lowfd);
+    IC_ORIG(closefrom)(lowfd);
   } else if (lowfd == fb_sv_conn) {
     /* Need to skip the first fd. */
-    ic_orig_closefrom(lowfd + 1);
+    IC_ORIG(closefrom)(lowfd + 1);
   } else {
     /* Need to leave a hole in the range. */
-    ic_orig_close_range(lowfd, fb_sv_conn - 1, 0);
-    ic_orig_closefrom(fb_sv_conn + 1);
+    IC_ORIG(close_range)(lowfd, fb_sv_conn - 1, 0);
+    IC_ORIG(closefrom)(fb_sv_conn + 1);
   }
 ### endblock call_orig


### PR DESCRIPTION
Followup from commit 03353c8df16b4032a9ca73a195655e73e452bad1.

My bad, my mind hasn't switched to using the new syntax yet.