### PR TITLE
ci: Use ppa:rbalint/hopscotch-map for fixed hopscotch-map version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
         key: build-on-ubuntu-lts
     - name: install-deps
       run: |
+        sudo add-apt-repository -y ppa:rbalint/hopscotch-map
         sudo eatmydata apt-get -y install $BUILD_DEPS $TEST_DEPS doxygen valgrind lcov
     - name: build-out-of-tree
       run: |
@@ -95,7 +96,9 @@ jobs:
         TZ=Europe/Budapest
         ln -snf /usr/share/zoneinfo/$TZ /etc/localtime
         echo $TZ > /etc/timezone
-        apt-get install -y eatmydata
+        apt-get -qq update
+        apt-get install -y eatmydata software-properties-common
+        add-apt-repository -y ppa:rbalint/hopscotch-map
         eatmydata apt-get -y install $BUILD_DEPS $TEST_DEPS g++ gcc
     - name: build-out-of-tree
       run: |
@@ -128,6 +131,7 @@ jobs:
         key: clang-build
     - name: install-deps
       run: |
+        sudo add-apt-repository -y ppa:rbalint/hopscotch-map
         sudo eatmydata apt-get -y install clang-tools-12 $BUILD_DEPS $TEST_DEPS
     - name: build
       run: |
@@ -164,6 +168,7 @@ jobs:
         key: rebuild-self
     - name: install-deps
       run: |
+        sudo add-apt-repository -y ppa:rbalint/hopscotch-map
         sudo eatmydata apt-get -y install $BUILD_DEPS
     - name: rebuild self
       run: |
@@ -208,6 +213,7 @@ jobs:
         sudo sed -i 's/# deb-src/deb-src/' /etc/apt/sources.list
         # work around https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1979244
         echo 'APT::Get::Always-Include-Phased-Updates "true";' | sudo tee /etc/apt/apt.conf.d/99-firebuild-phased-updates
+        sudo add-apt-repository -y -n ppa:rbalint/hopscotch-map
         sudo apt-get update
         sudo eatmydata apt-get -y install devscripts $BUILD_DEPS $TEST_DEPS
         sudo eatmydata apt-get build-dep vte2.91
@@ -253,6 +259,7 @@ jobs:
     - name: install-deps
       run: |
         ! [ ${{ matrix.os }} == "ubuntu-20.04" ] || sudo add-apt-repository -y -n ppa:rbalint/xxhash
+        sudo add-apt-repository -y -n ppa:rbalint/hopscotch-map
         sudo apt update
         sudo eatmydata apt-get build-dep .
     - name: deb


### PR DESCRIPTION
Improves #597.