### PR TITLE
supervisor: Add "sh" to skip cache

### DIFF
--- a/etc/firebuild.conf
+++ b/etc/firebuild.conf
@@ -52,6 +52,8 @@ processes = {
   // because they are fast enough).
   // This has no effect on potentially caching and shortcutting their ancestors.
   skip_cache = [
+    // default shell
+    "sh",
     // coreutils
     "arch", "basename", "cat", "chgrp", "chmod", "chown", "cp", "cut",
     "dd", "dir", "dirname", "expr", "head", "install", "link", "ln",


### PR DESCRIPTION
Saves 10% cache size at the expense of acceptable (0.2% real, 6% user+sys) slowdown in the second round.
Note that the slowdown is in percentage, not percentage point, thus compared to vanilla the second build's slowdown is 0.3%.

```
rbalint@zen:~$ ~/projects/firebuild-infra/perftest/compare_builds.R ~/buildtimes-tmp.csv jammy-v0.1-478-g0203eeb jammy-v0.1-479-g52d1746
Time % increase from jammy-v0.1-478-g0203eeb to jammy-v0.1-479-g52d1746 
comparing 188 run pairs.

     real1             user1              sys1         
 Min.   :-7.0108   Min.   :-6.1464   Min.   :-24.1546  
 1st Qu.:-0.7619   1st Qu.:-0.5019   1st Qu.: -2.8865  
 Median :-0.1363   Median : 0.1029   Median :  0.2819  
 Mean   :-0.1745   Mean   : 0.1193   Mean   :  0.2893  
 3rd Qu.: 0.5107   3rd Qu.: 0.9645   3rd Qu.:  2.8587  
 Max.   : 5.3683   Max.   : 3.5373   Max.   : 47.4227  

Max. real slowdown (%): bzip2

                 real1     user1       sys1
 Sum. incr.: 0.1418428 0.2228174 0.03039787

     real2             user2              sys2         
 Min.   :-5.5992   Min.   :-6.1420   Min.   :-33.3333  
 1st Qu.:-1.1176   1st Qu.:-0.4327   1st Qu.: -2.8347  
 Median :-0.3848   Median : 0.2380   Median : -0.2090  
 Mean   :-0.1570   Mean   : 0.4253   Mean   : -0.3018  
 3rd Qu.: 0.5023   3rd Qu.: 1.0648   3rd Qu.:  2.0992  
 Max.   : 7.6402   Max.   : 9.6311   Max.   : 29.6552  

Max. real slowdown (%): kcalc

                  real2     user2      sys2
 Sum. incr.: -0.2893149 0.2837388 0.2239267

     real3              user3              sys3        
 Min.   :-19.8925   Min.   :-36.321   Min.   :-63.441  
 1st Qu.: -1.0577   1st Qu.: -1.106   1st Qu.: -4.511  
 Median :  0.4078   Median :  3.862   Median :  2.327  
 Mean   :  5.6118   Mean   : 19.428   Mean   : 11.002  
 3rd Qu.:  2.1622   3rd Qu.: 17.440   3rd Qu.: 12.985  
 Max.   :180.0000   Max.   :440.000   Max.   :700.000  

Max. real slowdown (%): bzip2

                 real3    user3     sys3
 Sum. incr.: 0.3844037 6.489221 4.339009

Cache size % increase from jammy-v0.1-478-g0203eeb to jammy-v0.1-479-g52d1746
  cache.size.1      cache.size.2     
 Min.   :-41.165   Min.   :-38.7243  
 1st Qu.:-13.325   1st Qu.:-15.8627  
 Median : -2.218   Median : -2.2815  
 Mean   : -8.016   Mean   : -8.6798  
 3rd Qu.: -0.155   3rd Qu.: -0.1961  
 Max.   :  4.517   Max.   :  2.3092  

             cache.size.1 cache.size.2
 Sum. incr.:     -10.9606    -11.86209

Total time with firebuild (%) in jammy-v0.1-479-g52d1746 :
         first run second run
real      112.6564  21.786312
user      100.7192   3.835020
sys       134.6240  18.293544
user+sys  104.0581   5.258896
```
