### PR TITLE
Revert "interceptor: Call is_path_at_locations() only on absolute paths"

### DIFF
--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -282,9 +282,9 @@ generate("int", ["creat", "creat64"], "const char *pathname, mode_t mode",
 
 # Intercept fopen
 def open_ack_condition(msg):
-  return "success && (!path_is_absolute(pathname) || (" \
-    "!is_path_at_locations(fbbcomm_builder_" + msg + "_get_pathname(&ic_msg), fbbcomm_builder_" + msg + "_get_pathname_len(&ic_msg), &system_locations) " \
-    "&& !is_path_at_locations(fbbcomm_builder_" + msg + "_get_pathname(&ic_msg), fbbcomm_builder_" + msg + "_get_pathname_len(&ic_msg), &ignore_locations)))"
+  return "success " \
+    "&& !is_path_at_locations(fbbcomm_builder_" + msg + "_get_pathname(&ic_msg), fbbcomm_builder_" + msg + "_get_pathname_len(&ic_msg), &system_locations) " \
+    "&& !is_path_at_locations(fbbcomm_builder_" + msg + "_get_pathname(&ic_msg), fbbcomm_builder_" + msg + "_get_pathname_len(&ic_msg), &ignore_locations)"
 
 # Note: confusingly open()'s and fopen()'s manual uses the word "mode" for something completely different.
 generate("FILE *", ["fopen", "fopen64"], "const char *pathname, const char *mode",

--- a/src/interceptor/intercept.c
+++ b/src/interceptor/intercept.c
@@ -373,7 +373,7 @@ void send_pre_open_without_ack_request(const int dirfd, const char* pathname) {
 bool maybe_send_pre_open(const int dirfd, const char* pathname, int flags) {
   if (pathname && is_write(flags) && (flags & O_TRUNC)
       && !(flags & (O_EXCL | O_DIRECTORY |O_TMPFILE))
-      && (!path_is_absolute(pathname) || !is_path_at_locations(pathname, -1, &ignore_locations))) {
+      && !is_path_at_locations(pathname, -1, &ignore_locations)) {
     send_pre_open(dirfd, pathname);
     return true;
   } else {

--- a/src/interceptor/intercept.h
+++ b/src/interceptor/intercept.h
@@ -26,7 +26,6 @@
 #include <unistd.h>
 
 #include "common/firebuild_common.h"
-#include "common/platform.h"
 #include "./fbbcomm.h"
 
 /** A poor man's (plain C) implementation of a hashmap:

--- a/src/interceptor/tpl_open.c
+++ b/src/interceptor/tpl_open.c
@@ -21,7 +21,7 @@
 ### endif
 ### set after_lines = ["if (i_am_intercepting && success) clear_notify_on_read_write_state(ret);"]
 ### set send_ret_on_success=True
-### set ack_condition = "success && (!path_is_absolute(pathname) || (!is_path_at_locations(fbbcomm_builder_" + msg + "_get_pathname(&ic_msg), fbbcomm_builder_" + msg + "_get_pathname_len(&ic_msg), &system_locations) && !is_path_at_locations(fbbcomm_builder_" + msg + "_get_pathname(&ic_msg), fbbcomm_builder_" + msg + "_get_pathname_len(&ic_msg), &ignore_locations)))"
+### set ack_condition = "success && !is_path_at_locations(fbbcomm_builder_" + msg + "_get_pathname(&ic_msg), fbbcomm_builder_" + msg + "_get_pathname_len(&ic_msg), &system_locations) && !is_path_at_locations(fbbcomm_builder_" + msg + "_get_pathname(&ic_msg), fbbcomm_builder_" + msg + "_get_pathname_len(&ic_msg), &ignore_locations)"
 
 ### block before
 {{ super() }}


### PR DESCRIPTION
The change did not clearly improve performance, but clearly adds
to the code complexity.

This reverts commit 000751adecd51ae22425c2851a7d01fea9673c16.