### PR TITLE
Send pre_open and length when intercepting truncate()

### DIFF
--- a/src/common/fbbcomm.def
+++ b/src/common/fbbcomm.def
@@ -734,7 +734,8 @@
 
     ("truncate", [
       # name
-      (OPTIONAL, STRING, "pathname"),
+      (REQUIRED, STRING, "pathname"),
+      (REQUIRED, "long", "length"),
       # error no., when ret = -1
       (OPTIONAL, "int", "error_no"),
     ]),

--- a/src/firebuild/firebuild.cc
+++ b/src/firebuild/firebuild.cc
@@ -1158,8 +1158,8 @@ void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf,
       break;
     }
     case FBBCOMM_TAG_truncate: {
-      // FIXME Will be a bit tricky to implement, see #637.
-      proc->exec_point()->disable_shortcutting_bubble_up("truncate() is not supported");
+      ::firebuild::ProcessFBBAdaptor::handle(proc,
+          reinterpret_cast<const FBBCOMM_Serialized_truncate *>(fbbcomm_buf));
       break;
     }
     case FBBCOMM_TAG_unlink: {

--- a/src/firebuild/process.cc
+++ b/src/firebuild/process.cc
@@ -358,6 +358,26 @@ int Process::handle_close_range(const unsigned int first, const unsigned int las
   return 0;
 }
 
+int Process::handle_truncate(const char * const ar_name, const size_t ar_len,
+                             const off_t length, const int error) {
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this,
+         "ar_name=%s, length=%ld, error=%d", D(ar_name), length, error);
+
+  const FileName* name = get_absolute(AT_FDCWD, ar_name, ar_len);
+  if (!name) {
+    exec_point()->disable_shortcutting_bubble_up("Could not find file to truncate()");
+    return -1;
+  }
+  /* truncate() always sends pre_open. */
+  name->close_for_writing();
+
+  // FIXME Will be a bit tricky to implement shortcutting, see #637.
+  (void)length;
+  (void)error;
+  exec_point()->disable_shortcutting_bubble_up("truncate() is not supported");
+  return 0;
+}
+
 int Process::handle_unlink(const int dirfd, const char * const ar_name, const size_t ar_len,
                            const int flags, const int error, const bool pre_open_sent) {
   TRACKX(FB_DEBUG_PROC, 1, 1, Process, this,

--- a/src/firebuild/process.h
+++ b/src/firebuild/process.h
@@ -296,6 +296,12 @@ class Process {
                          const int flags, const int error = 0);
 
   /**
+   * Handle truncate() in the monitored process..
+   */
+  int handle_truncate(const char * const ar_name, const size_t ar_len,
+                      const off_t length, const int error);
+
+  /**
    * Handle unlink in the monitored process
    * @param dirfd the dirfd of unlinkat(), or AT_FDCWD
    * @param name relative or absolute file name

--- a/src/firebuild/process_fbb_adaptor.cc
+++ b/src/firebuild/process_fbb_adaptor.cc
@@ -60,6 +60,12 @@ int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_close_rang
   return proc->handle_close_range(msg->get_first(), msg->get_last(), msg->get_flags(), error);
 }
 
+int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_truncate *msg) {
+  const int error = msg->get_error_no_with_fallback(0);
+  return proc->handle_truncate(msg->get_pathname(), msg->get_pathname_len(),
+                               msg->get_length(), error);
+}
+
 int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_unlink *msg) {
   const int dirfd = msg->get_dirfd_with_fallback(AT_FDCWD);
   const int flags = msg->get_flags_with_fallback(0);

--- a/src/firebuild/process_fbb_adaptor.h
+++ b/src/firebuild/process_fbb_adaptor.h
@@ -25,6 +25,7 @@ class ProcessFBBAdaptor {
   static int handle(Process *proc, const FBBCOMM_Serialized_close *msg);
   static int handle(Process *proc, const FBBCOMM_Serialized_closefrom *msg);
   static int handle(Process *proc, const FBBCOMM_Serialized_close_range *msg);
+  static int handle(Process *proc, const FBBCOMM_Serialized_truncate *msg);
   static int handle(Process *proc, const FBBCOMM_Serialized_unlink *msg);
   static int handle(Process *proc, const FBBCOMM_Serialized_rmdir *msg);
   static int handle(Process *proc, const FBBCOMM_Serialized_mkdir *msg);

--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -1323,9 +1323,11 @@ generate("int", "pipe2", "int pipefd[2], int flags",
 
 # Intercept the truncate family
 generate("int", "truncate", "const char *pathname, off_t len",
+         before_lines=["if (i_am_intercepting) maybe_send_pre_open(AT_FDCWD, pathname, O_WRONLY | O_TRUNC);"],
          msg_skip_fields=["pathname", "len"],
          msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(truncate, pathname);"])
 generate("int", "truncate64", "const char *pathname, off64_t len",
+         before_lines=["if (i_am_intercepting) maybe_send_pre_open(AT_FDCWD, pathname, O_WRONLY | O_TRUNC);"],
          msg="truncate",
          msg_skip_fields=["pathname", "len"],
          msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(truncate, pathname);"])


### PR DESCRIPTION
This fixes tracking file writers and paves the way for shortcutting processes
calling truncate().

Improves #637.