### PR TITLE
supervisor: Don't deactivate abandoned recorders when disabling shortcutting

### DIFF
--- a/src/firebuild/pipe_recorder.cc
+++ b/src/firebuild/pipe_recorder.cc
@@ -174,7 +174,6 @@ void PipeRecorder::deactivate() {
   TRACKX(FB_DEBUG_PIPE, 1, 1, PipeRecorder, this, "");
 
   assert(!deactivated_);
-  assert(!abandoned_);
 
   if (fd_ >= 0) {
     close(fd_);


### PR DESCRIPTION
Fixes #970.