### PR TITLE
Avoid using deprecated egrep and fgrep

### DIFF
--- a/test/integration.bats
+++ b/test/integration.bats
@@ -214,7 +214,7 @@ setup() {
 }
 
 @test "popen() a statically linked binary and a normal one" {
-  ldd ./test_static 2>&1 | egrep -q '(not a dynamic executable|statically linked)'
+  ldd ./test_static 2>&1 | grep -Eq '(not a dynamic executable|statically linked)'
 
   for i in 1 2; do
     result=$(./run-firebuild -- ./test_cmd_popen ./test_static r)
@@ -227,7 +227,7 @@ setup() {
 }
 
 @test "fork() + exec() a statically linked binary" {
-  ldd ./test_static 2>&1 | egrep -q '(not a dynamic executable|statically linked)'
+  ldd ./test_static 2>&1 | grep -Eq '(not a dynamic executable|statically linked)'
 
   for i in 1 2; do
     result=$(./run-firebuild -- ./test_cmd_fork_exec ./test_static)
@@ -244,7 +244,7 @@ setup() {
 }
 
 @test "posix_spawn() a statically linked binary" {
-  ldd ./test_static 2>&1 | egrep -q '(not a dynamic executable|statically linked)'
+  ldd ./test_static 2>&1 | grep -Eq '(not a dynamic executable|statically linked)'
 
   for i in 1 2; do
     result=$(./run-firebuild -- ./test_cmd_posix_spawn ./test_static)
@@ -254,7 +254,7 @@ setup() {
 }
 
 @test "clone() a statically linked binary" {
-  ldd ./test_static 2>&1 | egrep -q '(not a dynamic executable|statically linked)'
+  ldd ./test_static 2>&1 | grep -Eq '(not a dynamic executable|statically linked)'
 
   for i in 1 2; do
     result=$(./run-firebuild -- ./test_cmd_clone ./test_static)
@@ -264,7 +264,7 @@ setup() {
 }
 
 @test "system() a statically linked binary" {
-  ldd ./test_static 2>&1 | egrep -q '(not a dynamic executable|statically linked)'
+  ldd ./test_static 2>&1 | grep -Eq '(not a dynamic executable|statically linked)'
 
   for i in 1 2; do
     result=$(./run-firebuild -- ./test_cmd_system './test_static 3' | tr '\n' ' ')

--- a/test/test_symbols
+++ b/test/test_symbols
@@ -66,7 +66,7 @@ close_range
 posix_spawn_file_actions_addclosefrom_np
 "
 # TODO(rbalint) provide properly versioned symbols in libfirebuild
-libs=$(LD_PRELOAD=libpthread.so.0 ldd "$binary_dir/src/interceptor/libfirebuild.so" | egrep 'lib(c|dl|pthread).so' | cut -d' ' -f3)
+libs=$(LD_PRELOAD=libpthread.so.0 ldd "$binary_dir/src/interceptor/libfirebuild.so" | grep -E 'lib(c|dl|pthread).so' | cut -d' ' -f3)
 (nm -D $libs | \
      grep ' [TWi] ' | \
      cut -d' ' -f3- ; \
@@ -93,7 +93,7 @@ grep '_chk$' < libc-symbols.txt > libc-fortify-symbols.txt
 fortify_missing=$(for chk in $(< libc-fortify-symbols.txt); do
   base="${chk%_chk}"
   base="${base#__}"
-  if fgrep -qx "$base" public-symbols.txt && ! fgrep -qx "$chk" public-symbols.txt; then
+  if grep -Fqx "$base" public-symbols.txt && ! grep -Fqx "$chk" public-symbols.txt; then
     echo "$chk"
   fi
 done)


### PR DESCRIPTION
Note: Freshly released grep-3.8 allegedly issues a warning on this deprecation