### PR TITLE
firebuild: Fix dlopen() followed by dlerror()

### DIFF
--- a/src/common/fbbcomm.def
+++ b/src/common/fbbcomm.def
@@ -493,9 +493,11 @@
       (OPTIONAL, "int", "flag"),
       # absolute filename where (if) the library was found
       (OPTIONAL, STRING, "absolute_filename"),
-      # dlopen() does not set errno. We don't have access to an error code,
-      # but to an error string.
-      (OPTIONAL, STRING, "error_string"),
+      # dlopen() does not set errno. Also, as per #920, we cannot get
+      # the error string in a simple way without altering the
+      # intercepted process's behavior and without nasty hacks. So let's
+      # just go with a simple boolean denoting success vs. failure.
+      (REQUIRED, "bool", "error"),
     ]),
 
     ("memfd_create", [

--- a/src/firebuild/process_fbb_adaptor.cc
+++ b/src/firebuild/process_fbb_adaptor.cc
@@ -35,7 +35,7 @@ int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_freopen *m
 
 int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_dlopen *msg, int fd_conn,
                              const int ack_num) {
-  if (!msg->has_error_string() && msg->has_absolute_filename()) {
+  if (!msg->get_error() && msg->has_absolute_filename()) {
     return proc->handle_open(AT_FDCWD,
                              msg->get_absolute_filename(), msg->get_absolute_filename_len(),
                              O_RDONLY, 0, -1, 0, fd_conn, ack_num, false, false);

--- a/src/interceptor/tpl_dlopen.c
+++ b/src/interceptor/tpl_dlopen.c
@@ -7,7 +7,7 @@
 ### extends "tpl.c"
 
 {% set msg_add_fields = ["if (absolute_filename != NULL) BUILDER_SET_ABSOLUTE_CANONICAL(" + msg + ", absolute_filename);",
-                         "if (!success) fbbcomm_builder_dlopen_set_error_string(&ic_msg, dlerror());"] %}
+                         "fbbcomm_builder_dlopen_set_error(&ic_msg, !success);"] %}
 
 ### block before
   thread_libc_nesting_depth++;
@@ -17,12 +17,18 @@
   thread_libc_nesting_depth--;
 
   char *absolute_filename = NULL;
-  if (ret != NULL) {
+  if (success) {
     struct link_map *map;
     if (dlinfo(ret, RTLD_DI_LINKMAP, &map) == 0) {
       /* Note: contrary to the dlinfo(3) manual page, this is not necessarily absolute. See #657.
        * We'll resolve to absolute when setting the FBB field. */
       absolute_filename = map->l_name;
+    } else {
+      /* As per #920, dlinfo() returning an error _might_ cause problems later on in the intercepted
+       * app, should it call dlerror(). A call to dlerror() would return a non-NULL string
+       * describing dlinfo()'s failure, rather than NULL describing dlopen()'s success. But why
+       * would any app invoke dlerror() after a successful dlopen()? Let's hope that in practice no
+       * application does this. */
     }
   }
 ### endblock after


### PR DESCRIPTION
Our intercepted dlopen() shouldn't call dlerror() in case of failure because the call is not idempotent, a subsequent dlerror() performed by the supervised application will incorrectly report success.

Fixes #920.