### PR TITLE
firebuild: Support the recv() and send() families

### DIFF
--- a/src/common/fbbcomm.def
+++ b/src/common/fbbcomm.def
@@ -764,7 +764,7 @@
       (OPTIONAL, "int", "error_no"),
     ]),
 
-    # The first time the process reads from the given inherited fd.
+    # The first time the process reads (including the recv() family) from the given inherited fd.
     # Also re-sent once with is_pread=true if that value was false the first time.
     ("read_from_inherited", [
       # file fd
@@ -777,7 +777,7 @@
       (OPTIONAL, "int", "error_no"),
     ]),
 
-    # The first time the process writes to the given inherited fd.
+    # The first time the process writes (including the send() family) to the given inherited fd.
     # Also re-sent once with is_pwrite=true if that value was false the first time.
     ("write_to_inherited", [
       # file fd

--- a/src/firebuild/process.h
+++ b/src/firebuild/process.h
@@ -490,16 +490,16 @@ class Process {
 
 
   /**
-   * Handle the first read()-like or the first pread()-like operation from an inherited fd in the
-   * monitored process
+   * Handle the first read()/recv()-like or the first pread()-like operation from an inherited fd in
+   * the monitored process
    * @param fd file descriptor
    * @param is_pread whether the read occurred at a specified position
    */
   void handle_read_from_inherited(const int fd, const bool is_pread);
 
   /**
-   * Handle the first write()-like or the first pwrite()-like operation to an inherited fd in the
-   * monitored process
+   * Handle the first write()/send()-like or the first pwrite()-like operation to an inherited fd in
+   * the monitored process
    * @param fd file descriptor
    * @param is_pwrite whether the write occurred at a specific position
    */

--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -656,6 +656,25 @@ for i in ['', '__isoc99_']:
     for w in ['', 'w']:
       skip(i + v + "s" + w + "scanf")
 
+generate("ssize_t", "recv", "int fd, void *buf, size_t len, int flags",
+         tpl="read",
+         msg_skip_fields=["buf", "len", "flags"])
+generate("ssize_t", "__recv_chk", "int fd, void *buf, size_t len, size_t fortify_size, int flags",
+         tpl="read",
+         msg_skip_fields=["buf", "len", "fortify_size", "flags"])
+generate("ssize_t", "recvfrom", "int fd, void *buf, size_t len, int flags, struct sockaddr *src_addr, socklen_t *addrlen",
+         tpl="read",
+         msg_skip_fields=["buf", "len", "flags", "src_addr", "addrlen"])
+generate("ssize_t", "__recvfrom_chk", "int fd, void *buf, size_t len, size_t fortify_size, int flags, struct sockaddr *src_addr, socklen_t *addrlen",
+         tpl="read",
+         msg_skip_fields=["buf", "len", "fortify_size", "flags", "src_addr", "addrlen"])
+generate("ssize_t", "recvmsg", "int fd, struct msghdr *msg, int flags",
+         tpl="read",
+         msg_skip_fields=["msg", "flags"])
+generate("int", "recvmmsg", "int fd, struct mmsghdr *msgvec, unsigned int vlen, int flags, struct timespec *timeout",
+         tpl="read",
+         msg_skip_fields=["msgvec", "vlen", "flags", "timeout"])
+
 # Intercept operations that write to a file descriptor.
 # FIXME also intercept mmap with PROT_WRITE
 generate("ssize_t", "write", "int fd, const void *buf, size_t count",
@@ -870,6 +889,19 @@ for v in ['', 'v']:
 for v in ['', 'v']:
   for (c1, c2) in [('', ''), ('__', '_chk')]:
     skip(c1 + v + "asprintf" + c2)
+
+generate("ssize_t", "send", "int fd, const void *buf, size_t len, int flags",
+         tpl="write",
+         msg_skip_fields=["buf", "len", "flags"])
+generate("ssize_t", "sendto", "int fd, const void *buf, size_t len, int flags, const struct sockaddr *dest_addr, socklen_t addrlen",
+         tpl="write",
+         msg_skip_fields=["buf", "len", "flags", "dest_addr", "addrlen"])
+generate("ssize_t", "sendmsg", "int fd, const struct msghdr *msg, int flags",
+         tpl="write",
+         msg_skip_fields=["msg", "flags"])
+generate("int", "sendmmsg", "int fd, struct mmsghdr *msgvec, unsigned int vlen, int flags",
+         tpl="write",
+         msg_skip_fields=["msgvec", "vlen", "flags"])
 
 # Intercept querying or modifying the file offset
 # FIXME What's up with llseek, _llseek, __lseek, _IO_*seek* etc.?
@@ -1782,7 +1814,6 @@ skip("confstr")
 # Network
 # FIXME use the "once" template instead: we need to know it can't be shortcut
 skip("getsockname", "getpeername")
-skip("send", "recv", "sendto", "recvfrom", "sendmsg", "recvmsg")
 skip("getsockopt", "setsockopt", "accept", "accept4", "shutdown", "sockatmark")
 
 # Mounts

--- a/src/interceptor/intercept.c
+++ b/src/interceptor/intercept.c
@@ -969,7 +969,10 @@ static void fb_ic_init() {
 
   /* Read the scproc_resp message header. */
   msg_header header;
-  ssize_t ret = fb_read(fb_sv_conn, &header, sizeof(header));
+#ifndef NDEBUG
+  ssize_t ret =
+#endif
+      fb_read(fb_sv_conn, &header, sizeof(header));
   assert(ret == sizeof(header));
   assert(header.msg_size > 0);
   uint16_t fd_count = header.fd_count;
@@ -1000,9 +1003,10 @@ static void fb_ic_init() {
   /* This is the first message arriving on the socket, and it's reasonably small.
    * We can safely expect that the header and the payload are fully available (no short read).
    * However, a signal interrupt might occur. */
-  do {
-    ret = recvmsg(fb_sv_conn, &msgh, 0);
-  } while (ret < 0 && errno == EINTR);
+#ifndef NDEBUG
+  ret =
+#endif
+      TEMP_FAILURE_RETRY(IC_ORIG(recvmsg)(fb_sv_conn, &msgh, 0));
   assert(ret == header.msg_size);
   assert(fbbcomm_serialized_get_tag(sv_msg_generic) == FBBCOMM_TAG_scproc_resp);
 

--- a/src/interceptor/tpl_read.c
+++ b/src/interceptor/tpl_read.c
@@ -2,7 +2,12 @@
 {# Copyright (c) 2020 Interri Kft.                                    #}
 {# This file is an unpublished work. All rights reserved.             #}
 {# ------------------------------------------------------------------ #}
-{# Template for functions reading from a file.                        #}
+{# Template for functions reading from a (regular or special) file,   #}
+{# including                                                          #}
+{# - low-level [p]read*() family                                      #}
+{# - high-level stdio like fread(), getc(), scanf() etc.              #}
+{# - low-level socket reading recv*() family                          #}
+{# and perhaps more.                                                  #}
 {# ------------------------------------------------------------------ #}
 ### extends "tpl.c"
 

--- a/src/interceptor/tpl_write.c
+++ b/src/interceptor/tpl_write.c
@@ -2,7 +2,13 @@
 {# Copyright (c) 2020 Interri Kft.                                    #}
 {# This file is an unpublished work. All rights reserved.             #}
 {# ------------------------------------------------------------------ #}
-{# Template for functions writing to a file.                          #}
+{# Template for functions writing to a (regular or special) file,     #}
+{# including                                                          #}
+{# - low-level [p]write*() family                                     #}
+{# - high-level stdio like fwrite(), putc(), printf(), perror() etc.  #}
+{# - low-level socket writing send*() family                          #}
+{# - ftruncate()                                                      #}
+{# and perhaps more.                                                  #}
 {# ------------------------------------------------------------------ #}
 ### extends "tpl.c"
 


### PR DESCRIPTION
Report calling the recv() or send() families on inherited fds to the supervisor, disable shortcutting if appropriate.

Fixes #981.