### PR TITLE
supervisor: Don't intercept Gradle

### DIFF
--- a/etc/firebuild.conf
+++ b/etc/firebuild.conf
@@ -42,6 +42,8 @@ processes = {
     "fakeroot",
     // similar build accelerator which is unlikely to be shortcut efficiently
     "ccache",
+    // hangs, also has its own caching framework
+    "gradle",
     // Go has its own caching framework
     "go",
     // Man uses seccomp sandboxing which prevents interception after the sandbox is set up.


### PR DESCRIPTION
It has its own caching framework and it hangs