### PR TITLE
supervisor: Set -Wno-strict-overflow for execed_process.cc

### DIFF
--- a/src/firebuild/CMakeLists.txt
+++ b/src/firebuild/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 # GCC raises warning about the GCC-optimized code
-set_source_files_properties(execed_process_cacher.cc file_name.cc obj_cache.cc utils.cc PROPERTIES COMPILE_FLAGS "-Wno-strict-overflow")
+set_source_files_properties(execed_process.cc execed_process_cacher.cc file_name.cc obj_cache.cc utils.cc PROPERTIES COMPILE_FLAGS "-Wno-strict-overflow")
 
 set_source_files_properties(firebuild.cc PROPERTIES COMPILE_FLAGS "-DFIREBUILD_VERSION='\"${FIREBUILD_VERSION}\"'")
 


### PR DESCRIPTION
export2js() triggers the warning.