### PR TITLE
Improve open(path, O_TMPFILE) handling

### DIFF
--- a/src/firebuild/file_fd.h
+++ b/src/firebuild/file_fd.h
@@ -31,9 +31,11 @@ class Pipe;
 
 /* We don't track these "file creation flags" because fcntl(F_SETFL) ignores them and fcntl(F_GETFL)
  * doesn't report them back. The list is taken from the open(2) manpage.
- * Also O_CLOEXEC is tracked in FileFD where it belongs to, rather than in FileOFD. */
+ * Also O_CLOEXEC is tracked in FileFD where it belongs to, rather than in FileOFD.
+ * O_TMPFILE is not listed here, because it is multiple bits and also does not create a named file.
+ * */
 #define FILE_CREATION_FLAGS (O_CLOEXEC | O_CREAT | O_DIRECTORY | O_EXCL | O_NOCTTY | O_NOFOLLOW | \
-                             O_TMPFILE | O_TRUNC)
+                             O_TRUNC)
 
 /**
  * Represents an "open file description" ("ofd") of the intercepted processes, as per the term's

--- a/src/interceptor/intercept.c
+++ b/src/interceptor/intercept.c
@@ -372,7 +372,8 @@ void send_pre_open_without_ack_request(const int dirfd, const char* pathname) {
 
 bool maybe_send_pre_open(const int dirfd, const char* pathname, int flags) {
   if (pathname && is_write(flags) && (flags & O_TRUNC)
-      && !(flags & (O_EXCL | O_DIRECTORY |O_TMPFILE))
+      && !(flags & (O_EXCL | O_DIRECTORY))
+      && (flags & O_TMPFILE) != O_TMPFILE
       && !is_path_at_locations(pathname, -1, &ignore_locations)) {
     send_pre_open(dirfd, pathname);
     return true;


### PR DESCRIPTION
Properly check O_TMPFILE flag in the interceptor and the supervisor. Register the directory the unnamed file is opened in instead of wrongly treating the path as a regular opened named file.

Fixes #77.