### PR TITLE
supervisor: Disable shortcutting processes performing a failed rename()

### DIFF
--- a/src/firebuild/process.cc
+++ b/src/firebuild/process.cc
@@ -955,7 +955,8 @@ int Process::handle_rename(const int olddirfd, const char * const old_ar_name,
 
   if (error) {
     // TODO(rbalint) add detailed error handling
-    return 0;
+    exec_point()->disable_shortcutting_bubble_up("Failed rename() is not supported");
+    return -1;
   }
 
   if (!old_name || !new_name) {


### PR DESCRIPTION
Fixes rcs build.