### PR TITLE
supervisor: Remove expectedly read-only files before replacing them

### DIFF
--- a/src/firebuild/blob_cache.cc
+++ b/src/firebuild/blob_cache.cc
@@ -382,9 +382,10 @@ bool BlobCache::retrieve_file(const Hash &key,
   int flags = append ? O_WRONLY : (O_WRONLY|O_CREAT|O_TRUNC);
   int fd_dst = open(path_dst->c_str(), flags, 0666);
   if (fd_dst == -1) {
-    fb_perror("Failed opening file to be recreated from cache");
-    assert(0);
-    close(fd_src);
+    if (append) {
+      fb_perror("Failed opening file to be recreated from cache");
+      assert(0);
+    }
     return false;
   }
 


### PR DESCRIPTION
This fixes shortcutting in rare cases where initially read-only files are written. One example is dh_autoreconf replacing read-only include/argus_config.h.in in argus-clients' build.