### PR TITLE
firebuild: Register read/write/seek failures in inherited fds

### DIFF
--- a/src/common/fbbcomm.def
+++ b/src/common/fbbcomm.def
@@ -764,7 +764,7 @@
       (OPTIONAL, "int", "error_no"),
     ]),
 
-    # The first time the process reads (including the recv() family) from the given inherited fd.
+    # The first time the process attempts to read (including the recv() family) from the given inherited fd.
     # Also re-sent once with is_pread=true if that value was false the first time.
     ("read_from_inherited", [
       # file fd
@@ -773,11 +773,9 @@
       # rather than at the file's current offset in a way that advances this offset.
       # Also false if preadv2() with offset == -1 mimics plain old sequential read().
       (REQUIRED, "bool", "is_pread"),
-      # error no., when ret = -1
-      (OPTIONAL, "int", "error_no"),
     ]),
 
-    # The first time the process writes (including the send() family) to the given inherited fd.
+    # The first time the process attempts to write (including the send() family) to the given inherited fd.
     # Also re-sent once with is_pwrite=true if that value was false the first time.
     ("write_to_inherited", [
       # file fd
@@ -786,19 +784,15 @@
       # rather than at the file's current offset in a way that advances this offset.
       # Also false if pwritev2() with offset == -1 mimics plain old sequential write().
       (REQUIRED, "bool", "is_pwrite"),
-      # error no., when ret = -1
-      (OPTIONAL, "int", "error_no"),
     ]),
 
-    # The first time the process queries or changes the seek offset.
+    # The first time the process attempts to query or change the seek offset.
     # Also re-sent once with modify_offset=true if that value was false the first time.
     ("seek_in_inherited", [
       # file fd
       (REQUIRED, "int", "fd"),
       # Whether the operation requested to change the offset
       (REQUIRED, "bool", "modify_offset"),
-      # error no., when ret = -1
-      (OPTIONAL, "int", "error_no"),
     ]),
 
     # Received some file descriptors via a recv[m]msg() and SCM_RIGHTS.

--- a/src/firebuild/process_fbb_adaptor.cc
+++ b/src/firebuild/process_fbb_adaptor.cc
@@ -175,26 +175,17 @@ int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_ioctl *msg
 }
 
 int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_read_from_inherited *msg) {
-  const int error = msg->get_error_no_with_fallback(0);
-  if (error == 0) {
-    proc->handle_read_from_inherited(msg->get_fd(), msg->get_is_pread());
-  }
+  proc->handle_read_from_inherited(msg->get_fd(), msg->get_is_pread());
   return 0;
 }
 
 int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_write_to_inherited *msg) {
-  const int error = msg->get_error_no_with_fallback(0);
-  if (error == 0) {
-    proc->handle_write_to_inherited(msg->get_fd(), msg->get_is_pwrite());
-  }
+  proc->handle_write_to_inherited(msg->get_fd(), msg->get_is_pwrite());
   return 0;
 }
 
 int ProcessFBBAdaptor::handle(Process *proc, const FBBCOMM_Serialized_seek_in_inherited *msg) {
-  const int error = msg->get_error_no_with_fallback(0);
-  if (error == 0) {
-    proc->handle_seek_in_inherited(msg->get_fd(), msg->get_modify_offset());
-  }
+  proc->handle_seek_in_inherited(msg->get_fd(), msg->get_modify_offset());
   return 0;
 }
 

--- a/src/interceptor/tpl_read.c
+++ b/src/interceptor/tpl_read.c
@@ -15,6 +15,11 @@
 ###   set is_pread = "false"
 ### endif
 
+### if msg_skip_fields is not defined
+###   set msg_skip_fields = []
+### endif
+### do msg_skip_fields.append("error_no")
+
 {% set msg = "read_from_inherited" %}
 {# No locking around the read(): see issue #279 #}
 {% set global_lock = 'never' %}

--- a/src/interceptor/tpl_seek.c
+++ b/src/interceptor/tpl_seek.c
@@ -6,6 +6,11 @@
 {# ------------------------------------------------------------------ #}
 ### extends "tpl.c"
 
+### if msg_skip_fields is not defined
+###   set msg_skip_fields = []
+### endif
+### do msg_skip_fields.append("error_no")
+
 {% set msg = "seek_in_inherited" %}
 {# No locking around the seek(), to follow the pattern of tpl_{read,write}.c #}
 {% set global_lock = 'never' %}

--- a/src/interceptor/tpl_write.c
+++ b/src/interceptor/tpl_write.c
@@ -16,6 +16,11 @@
 ###   set is_pwrite = "false"
 ### endif
 
+### if msg_skip_fields is not defined
+###   set msg_skip_fields = []
+### endif
+### do msg_skip_fields.append("error_no")
+
 {% set msg = "write_to_inherited" %}
 {# No locking around the write(): see issue #279 #}
 {% set global_lock = 'never' %}


### PR DESCRIPTION
Handle failed attempts just as succeeded ones, so that a success after a failure doesn't go unnoticed.

Fixes #907.