### PR TITLE
supervisor: Check cache's version and use it only when the format is known

### DIFF
--- a/src/firebuild/execed_process_cacher.h
+++ b/src/firebuild/execed_process_cacher.h
@@ -24,6 +24,7 @@ namespace firebuild {
 class ExecedProcessCacher {
  public:
   static void init(const libconfig::Config* cfg);
+  static unsigned int cache_format() {return cache_format_;}
   bool fingerprint(const ExecedProcess *proc);
   void erase_fingerprint(const ExecedProcess *proc);
 
@@ -61,6 +62,7 @@ class ExecedProcessCacher {
    * purposes, only if debugging is enabled. In serialized FBBFP format. */
   tsl::hopscotch_map<const ExecedProcess*, std::vector<char>> fingerprint_msgs_;
 
+  static unsigned int cache_format_;
   DISALLOW_COPY_AND_ASSIGN(ExecedProcessCacher);
 };
 

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -337,3 +337,29 @@ setup() {
   assert_streq "$result" ""
   rm -f foo
 }
+
+@test "cache-format" {
+  result=$(./run-firebuild -d cache -- bash -c 'echo foo > foo')
+  assert_streq "$result" ""
+  assert_streq "$(strip_stderr stderr)" ""
+  assert_streq "$(cat test_cache_dir/cache-format)" "1"
+
+  # older cache versions are OK (assuming they are handled)
+  echo 0 > test_cache_dir/cache-format
+  result=$(./run-firebuild -d cache -- bash -c 'echo foo > foo')
+  assert_streq "$result" ""
+  assert_streq "$(strip_stderr stderr)" ""
+  assert_streq "$(cat test_cache_dir/cache-format)" "0"
+
+  # future cache versions prevent using the cache
+  echo 2 > test_cache_dir/cache-format
+  result=$(./run-firebuild -d cache -- bash -c 'echo foo > foo')
+  assert_streq "$result" ""
+  assert_streq "$(strip_stderr stderr)" "FIREBUILD ERROR: Cache format version is not supported, not reading or writing the cache"
+
+  # unknown cache versions prevent using the cache, too
+  echo foo > test_cache_dir/cache-format
+  result=$(./run-firebuild -d cache -- bash -c 'echo foo > foo')
+  assert_streq "$result" ""
+  assert_streq "$(strip_stderr stderr)" "FIREBUILD ERROR: Cache format version is not supported, not reading or writing the cache"
+}


### PR DESCRIPTION

Fixes #544.