### PR TITLE
supervisor: Add conftest.c's hash to the fingerprint

### DIFF
--- a/etc/firebuild.conf
+++ b/etc/firebuild.conf
@@ -117,7 +117,11 @@ quirks = [
   // This quirk allows shortcutting make and touch when it is run by lto-wrapper.
   // Since the internal make is started in /tmp the ignore-tmp-listing quirk needs to
   // be enabled as well to shortcut lto-wrapper.
-  "lto-wrapper"
+  "lto-wrapper",
+  // Guess if a command parameter is a file and include the hash of the file in the process fingerprint.
+  // This typically speeds up shortcutting, but may prevent shortcutting when the files passed to a command
+  // as parameters already exist and their content would not be read by the command.
+  "guess-file-params"
 ];
 
 // The cache can contain multiple candidate entres for shortcutting a command.

--- a/src/firebuild/config.cc
+++ b/src/firebuild/config.cc
@@ -260,6 +260,8 @@ void read_config(libconfig::Config *cfg, const char *custom_cfg_file,
         quirks |= FB_QUIRK_LTO_WRAPPER;
       } else if (quirk == "ignore-time-queries") {
         quirks |= FB_QUIRK_IGNORE_TIME_QUERIES;
+      } else if (quirk == "guess-file-params") {
+        quirks |= FB_QUIRK_GUESS_FILE_PARAMS;
       } else {
         if (FB_DEBUGGING(FB_DEBUG_CONFIG)) {
           std::cerr <<"Ignoring unknown quirk: " + quirk << std::endl;

--- a/src/firebuild/config.h
+++ b/src/firebuild/config.h
@@ -35,6 +35,7 @@ extern int shortcut_tries;
 extern int quirks;
 #define FB_QUIRK_IGNORE_TMP_LISTING  0x01
 #define FB_QUIRK_LTO_WRAPPER         0x02
+#define FB_QUIRK_GUESS_FILE_PARAMS   0x04
 #define FB_QUIRK_IGNORE_TIME_QUERIES 0x08
 
 void read_config(libconfig::Config *cfg, const char *custom_cfg_file,

--- a/src/firebuild/fbbfp.def
+++ b/src/firebuild/fbbfp.def
@@ -90,6 +90,7 @@
       (REQUIRED, STRING, "original_executed_path"),   # tag "file"
       # Command parameters, starting with name of the command
       (ARRAY,    STRING, "args"),
+      (OPTIONAL, "XXH128_hash_t", "param_file_hash"),
       # Environment variables, filtered (to exclude e.g. $FB_SOCKET)
       # and sorted to a deterministic order
       (ARRAY,    STRING, "env"),

--- a/src/firebuild/process.cc
+++ b/src/firebuild/process.cc
@@ -1308,7 +1308,8 @@ const FileName* Process::get_fd_filename(int fd) const {
   }
 }
 
-const FileName* Process::get_absolute(const int dirfd, const char * const name, ssize_t length) {
+const FileName* Process::get_absolute(const int dirfd, const char * const name,
+                                      ssize_t length) const {
   TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "dirfd=%d, name=%s, length=%ld",
          dirfd, D(name), length);
 

--- a/src/firebuild/process.h
+++ b/src/firebuild/process.h
@@ -216,7 +216,7 @@ class Process {
    * (possibly AT_FDCWD for the current directory). Return nullptr if the path is relative and
    * dirfd is invalid.
    */
-  const FileName* get_absolute(const int dirfd, const char * const name, ssize_t length);
+  const FileName* get_absolute(const int dirfd, const char * const name, ssize_t length) const;
 
   /**
    * Handle preparation for file opening in the monitored process


### PR DESCRIPTION
Also add guess-file-params quirk to control similar additions.

Improves #1017.