### PR TITLE
supervisor: Update mtime of cache objects used for shortcutting

### DIFF
--- a/src/firebuild/ascii_hash.h
+++ b/src/firebuild/ascii_hash.h
@@ -15,6 +15,7 @@ namespace firebuild {
 
 class AsciiHash {
  public:
+  AsciiHash() = default;
   explicit AsciiHash(const char * const str) {
 #ifdef FB_EXTRA_DEBUG
     assert(Hash::valid_ascii(str));

--- a/src/firebuild/execed_process_cacher.h
+++ b/src/firebuild/execed_process_cacher.h
@@ -32,7 +32,8 @@ class ExecedProcessCacher {
 
   const FBBSTORE_Serialized_process_inputs_outputs *find_shortcut(const ExecedProcess *proc,
                                                                   uint8_t **inouts_buf,
-                                                                  size_t *inouts_buf_len);
+                                                                  size_t *inouts_buf_len,
+                                                                  AsciiHash* subkey_out);
   bool apply_shortcut(ExecedProcess *proc,
                       const FBBSTORE_Serialized_process_inputs_outputs *inouts,
                       std::vector<int> *fds_appended_to);

--- a/src/firebuild/obj_cache.h
+++ b/src/firebuild/obj_cache.h
@@ -31,6 +31,7 @@ class ObjCache {
   bool retrieve(const char* path,
                 uint8_t ** entry,
                 size_t * entry_len);
+  void mark_as_used(const Hash &key, const char * const subkey);
   std::vector<AsciiHash> list_subkeys(const Hash &key);
   void gc(tsl::hopscotch_set<AsciiHash>* referenced_blobs);
 


### PR DESCRIPTION
This allows implementing LRU cache entry deletion in the GC.

Improves #967.