### PR TITLE
supervisor: Open each blob before applying a shortcut

### DIFF
--- a/src/firebuild/blob_cache.h
+++ b/src/firebuild/blob_cache.h
@@ -32,7 +32,7 @@ class BlobCache {
                        int fd,
                        size_t size,
                        Hash *key_out);
-  bool retrieve_file(const Hash &key,
+  bool retrieve_file(int blob_fd,
                      const FileName *path_dst,
                      bool append);
   int get_fd_for_file(const Hash &key);


### PR DESCRIPTION
This makes sure that a parallel GC run does not clean up the blob just before using in in shortcutting.

Fixes #1013.