### PR TITLE
debian: Make firebuild depend on libfirebuild0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,6 +26,7 @@ Package: firebuild
 Architecture: any
 Depends: ${shlibs:Depends},
          ${misc:Depends},
+         libfirebuild0 (= ${binary:Version})
 Suggests: graphviz,
           node-d3
 Description: Build analyzer and catalyst


### PR DESCRIPTION
Fixes #1060.