### PR TITLE
interceptor: Define signal syscall's return as long int

### DIFF
--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -1823,7 +1823,10 @@ generate("int", "fexecve", "int fd, char *const argv[], char *const envp[]",
 
 # Signal handling
 # FIXME SYS_osf_signal, SYS_osf_old_sigsetmask, SYS_osf_old_sigaction
-generate("sighandler_t", ["signal", "SYS_signal", "sigset"], "int signum, sighandler_t handler",
+generate("sighandler_t", ["signal", "sigset"], "int signum, sighandler_t handler",
+         tpl="signal",
+         success="1")
+generate("long int", ["SYS_signal"], "int signum, sighandler_t handler",
          tpl="signal",
          success="1")
 generate("int", ["sigaction", "SYS_sigaction"], "int signum, const struct sigaction *act, struct sigaction *oldact",

--- a/src/interceptor/tpl_signal.c
+++ b/src/interceptor/tpl_signal.c
@@ -14,12 +14,16 @@
 ### block call_orig
 ###   if func in ['signal', 'SYS_signal', 'sigset']
   if (signal_is_wrappable(signum)) {
+###     if func in ['signal', 'sigset']
     sighandler_t old_orig_signal_handler = (sighandler_t)orig_signal_handlers[signum - 1];
-    orig_signal_handlers[signum - 1] = (void (*)(void))handler;
+###     else
+    long int old_orig_signal_handler = (long int)orig_signal_handlers[signum - 1];
+###     endif
     sighandler_t new_signal_handler =
         (handler == SIG_IGN || handler == SIG_DFL) ? handler : wrapper_signal_handler_1arg;
+    orig_signal_handlers[signum - 1] = (void (*)(void))handler;
     ret = ic_orig_{{ func }}(signum, new_signal_handler);
-    if (ret == wrapper_signal_handler_1arg) {
+    if ((void (*)(int))ret == wrapper_signal_handler_1arg) {
       ret = old_orig_signal_handler;
     }
   } else {


### PR DESCRIPTION
While the signal() libc wrapper returns sighandler_t, syscall()'s return is long int and this attempted conversion caused build failures on ppc64el and s390x.