### PR TITLE
debian: Set XS-Autobuild: yes in debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,6 +22,7 @@ Build-Depends: bats,
 Standards-Version: 4.4.1
 Homepage: https://firebuild.com
 Rules-Requires-Root: no
+XS-Autobuild: yes
 
 Package: firebuild
 Architecture: any


### PR DESCRIPTION
The license allows building the package and distributing the binaries and building the package is technically possible on all architectures.