### PR TITLE
interceptor: Resolve intercepted symbols on demand

### DIFF
--- a/src/interceptor/CMakeLists.txt
+++ b/src/interceptor/CMakeLists.txt
@@ -13,7 +13,7 @@ if (SANITIZE)
 endif()
 
 add_custom_command (
-  OUTPUT gen_decl.h gen_def.c gen_impl.c gen_impl_syscalls.c.inc gen_init.c gen_list.txt gen_reset.c
+  OUTPUT gen_decl.h gen_def.c gen_impl.c gen_impl_syscalls.c.inc gen_list.txt gen_reset.c
   DEPENDS generate_interceptors
   tpl.c
   tpl_clone.c
@@ -50,7 +50,7 @@ add_custom_command (
   COMMAND ./generate_interceptors ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Generating interceptor files from templates")
 
-add_custom_target(gen_files ALL DEPENDS gen_decl.h gen_def.c gen_impl.c gen_impl_syscalls.c.inc gen_init.c gen_list.txt gen_reset.c)
+add_custom_target(gen_files ALL DEPENDS gen_decl.h gen_def.c gen_impl.c gen_impl_syscalls.c.inc gen_list.txt gen_reset.c)
 
 add_library(firebuild SHARED
   env.c

--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -26,8 +26,8 @@ if len(sys.argv) != 2:
   exit(1)
 outdir = sys.argv[1]
 
-libc_outputs = ['decl.h', 'def.c', 'impl.c', 'init.c', 'list.txt', 'reset.c']
-syscall_outputs = ['decl.h', 'def.c', 'impl_syscalls.c.inc', 'init.c', 'reset.c']
+libc_outputs = ['decl.h', 'def.c', 'impl.c', 'list.txt', 'reset.c']
+syscall_outputs = ['decl.h', 'def.c', 'impl_syscalls.c.inc', 'reset.c']
 env = Environment(loader=FileSystemLoader('.'),
                   line_statement_prefix='###',
                   trim_blocks=True,
@@ -266,11 +266,14 @@ def generate(rettype, funcs, sig, **dict):
     if func[:4] == 'SYS_':
       syscall = True
       outputs = syscall_outputs
+      call_ic_orig_func = "ic_orig_" + func
     else:
       syscall = False
       outputs = libc_outputs
+      call_ic_orig_func = "get_ic_orig_" + func + "()"
     for gen in outputs:
-      rendered = template.render(gen=gen, rettype=rettype, func=func, syscall=syscall, **dict)
+      rendered = template.render(gen=gen, rettype=rettype, func=func, syscall=syscall,
+                                 call_ic_orig_func=call_ic_orig_func, **dict)
       if rendered:
         with open(outdir + "/gen_" + gen + tmpsuffix, "a") as f:
           f.write(rendered)
@@ -280,8 +283,8 @@ def generate(rettype, funcs, sig, **dict):
 #
 # This does two things:
 #
-# Creates a "#define ic_orig_func func" redirect so that you can always
-# call ic_orig_foo() in the interceptor code, without worrying whether
+# Creates a "#define get_ic_orig_func() func" redirect so that you can always
+# call get_ic_orig_foo()(args) in the interceptor code, without worrying whether
 # that method is overridden or not.
 #
 # Also makes sure to exit with an error if there's a
@@ -465,7 +468,7 @@ generate("DIR *", "opendir", "const char *pathname",
          msg="open",
          msg_skip_fields=["pathname"],
          msg_add_fields=["fbbcomm_builder_open_set_flags(&ic_msg, O_RDONLY | O_CLOEXEC | O_DIRECTORY);",
-                         "if (success) fbbcomm_builder_open_set_ret(&ic_msg, ic_orig_dirfd(ret));",
+                         "if (success) fbbcomm_builder_open_set_ret(&ic_msg, get_ic_orig_dirfd()(ret));",
                          "BUILDER_SET_ABSOLUTE_CANONICAL(open, pathname);",
                          "fbbcomm_builder_open_set_pre_open_sent(&ic_msg, false);"],
          ack_condition=open_ack_condition("open"))
@@ -737,7 +740,7 @@ for i in ['', '__isoc99_']:
           msg_skip_fields += ["ap"]
         else:
           sig_str += "..."
-          call_orig_lines = ["ret = ic_orig_" + i + "v" + f + w + "scanf(" + names_str + "ap);"]
+          call_orig_lines = ["ret = get_ic_orig_" + i + "v" + f + w + "scanf()(" + names_str + "ap);"]
         generate("int", func, sig_str,
                  tpl="read",
                  success=success,
@@ -895,7 +898,7 @@ generate("void", "error", "int status, int errnum, const char *format, ...",
                           "char msgbuf[msglen + 1];",
                           "va_start(ap, format);",
                           "vsnprintf(msgbuf, msglen + 1, format, ap);",
-                          "ic_orig_error(status, errnum, \"%s\", msgbuf);"],
+                          "get_ic_orig_error()(status, errnum, \"%s\", msgbuf);"],
          msg_skip_fields=["status", "errnum", "format"],
          msg_add_fields=["fbbcomm_builder_write_to_inherited_set_fd(&ic_msg, fd);"])
 generate("void", "error_at_line", "int status, int errnum, const char *filename, unsigned int linenum, const char *format, ...",
@@ -906,7 +909,7 @@ generate("void", "error_at_line", "int status, int errnum, const char *filename,
                           "char msgbuf[msglen + 1];",
                           "va_start(ap, format);",
                           "vsnprintf(msgbuf, msglen + 1, format, ap);",
-                          "ic_orig_error_at_line(status, errnum, filename, linenum, \"%s\", msgbuf);"],
+                          "get_ic_orig_error_at_line()(status, errnum, filename, linenum, \"%s\", msgbuf);"],
          msg_skip_fields=["status", "errnum", "filename", "linenum", "format"],
          msg_add_fields=["fbbcomm_builder_write_to_inherited_set_fd(&ic_msg, fd);"])
 generate("void", ["herror", "perror"], "const char *s",
@@ -938,7 +941,7 @@ for v in ['', 'v']:
         msg_skip_fields += ["ap"]
       else:
         sig_str += "..."
-        call_orig_lines = ["ic_orig_v" + e + x + "(" + names_str + "ap);"]
+        call_orig_lines = ["get_ic_orig_v" + e + x + "()(" + names_str + "ap);"]
       generate("void", func, sig_str,
          tpl=tpl,
          before_lines=["int fd = safe_fileno(stderr);"],
@@ -989,7 +992,7 @@ for v in ['', 'v']:
           msg_skip_fields += ["ap"]
         else:
           sig_str += "..."
-          call_orig_lines = ["ret = ic_orig_" + c1 + "v" + f + w + "printf" + c2 + "(" + names_str + "ap);"]
+          call_orig_lines = ["ret = get_ic_orig_" + c1 + "v" + f + w + "printf" + c2 + "()(" + names_str + "ap);"]
         generate("int", func, sig_str,
                  tpl="write",
                  before_lines=before_lines,
@@ -1108,13 +1111,13 @@ generate("int", ["chdir", "SYS_chdir"], "const char *pathname",
          # Don't make pathname absolute, since the macro would calculate it after calling chdir
          msg_add_fields=["BUILDER_SET_CANONICAL(chdir, pathname);",
                          "if (success) {",
-                         "  char* getcwd_ret = ic_orig_getcwd(ic_cwd, IC_PATH_BUFSIZE);",
+                         "  char* getcwd_ret = get_ic_orig_getcwd()(ic_cwd, IC_PATH_BUFSIZE);",
                          "  (void) getcwd_ret;",
                          "  ic_cwd_len = strlen(ic_cwd);",
                          "}"])
 generate("int", ["fchdir", "SYS_fchdir"], "int fd",
          after_lines=["if (success) {",
-                      "  char* getcwd_ret = ic_orig_getcwd(ic_cwd, IC_PATH_BUFSIZE);",
+                      "  char* getcwd_ret = get_ic_orig_getcwd()(ic_cwd, IC_PATH_BUFSIZE);",
                       "  (void) getcwd_ret;",
                       "  ic_cwd_len = strlen(ic_cwd);",
                       "}"])

--- a/src/interceptor/ic_file_ops.h
+++ b/src/interceptor/ic_file_ops.h
@@ -35,7 +35,7 @@ void copy_notify_on_read_write_state(const int to_fd, const int from_fd);
 
 /* Same as fileno(), but with safe NULL pointer handling. */
 static inline int safe_fileno(FILE *stream) {
-  int ret = stream ? ic_orig_fileno(stream) : -1;
+  int ret = stream ? get_ic_orig_fileno()(stream) : -1;
   if (ret == fb_sv_conn) {
     assert(0 && "fileno() returned the connection fd");
   }
@@ -44,7 +44,7 @@ static inline int safe_fileno(FILE *stream) {
 
 /* Same as dirfd(), but with safe NULL pointer handling. */
 static inline int safe_dirfd(DIR *dirp) {
-  int ret = dirp ? ic_orig_dirfd(dirp) : -1;
+  int ret = dirp ? get_ic_orig_dirfd()(dirp) : -1;
   if (ret == fb_sv_conn) {
     assert(0 && "dirfd() returned the connection fd");
   }

--- a/src/interceptor/interceptors.c
+++ b/src/interceptor/interceptors.c
@@ -30,9 +30,7 @@
 #include "interceptor/intercept.h"
 
 void init_interceptors() {
-/* Include the auto-generated initializations of the ic_orig function pointers */
-#include "interceptor/gen_init.c"
-
+/* Include the auto-generated initializations of the get_ic_orig function pointers */
   reset_interceptors();
 }
 
@@ -41,7 +39,7 @@ void reset_interceptors() {
 #include "interceptor/gen_reset.c"
 }
 
-/* Include the auto-generated definitions of the ic_orig function pointers */
+/* Include the auto-generated definitions of the get_ic_orig function pointers */
 #include "interceptor/gen_def.c"
 
 /* Include the auto-generated implementations of the interceptor functions */

--- a/src/interceptor/interceptors.h
+++ b/src/interceptor/interceptors.h
@@ -78,7 +78,7 @@ struct ustat;
 void init_interceptors();
 void reset_interceptors();
 
-/* Include the auto-generated declarations of the ic_orig function pointers,
+/* Include the auto-generated declarations of the get_ic_orig function pointers,
  * and some convenience #define redirects */
 #include "interceptor/gen_decl.h"
 

--- a/src/interceptor/tpl__exit.c
+++ b/src/interceptor/tpl__exit.c
@@ -40,7 +40,7 @@
   handle_exit({{ names_str }});
 
   /* Perform the call */
-  ic_orig_{{ func }}({{ names_str }});
+  {{ call_ic_orig_func }}({{ names_str }});
 
   /* Make scan-build happy */
   (void)i_locked;

--- a/src/interceptor/tpl_clone.c
+++ b/src/interceptor/tpl_clone.c
@@ -47,18 +47,18 @@
   }
 
   if (vararg_count == 0) {
-    ret = ic_orig_{{ func }}(fn, stack, flags, arg);
+    ret = get_ic_orig_{{ func }}()(fn, stack, flags, arg);
   } else {
     pid_t *parent_tid = va_arg(ap, pid_t *);
     if (vararg_count == 1) {
-      ret = ic_orig_{{ func }}(fn, stack, flags, arg, parent_tid);
+      ret = get_ic_orig_{{ func }}()(fn, stack, flags, arg, parent_tid);
     } else {
       void *tls = va_arg(ap, void *);
       if (vararg_count == 2) {
-        ret = ic_orig_{{ func }}(fn, stack, flags, arg, parent_tid, tls);
+        ret = get_ic_orig_{{ func }}()(fn, stack, flags, arg, parent_tid, tls);
       } else {
         pid_t *child_tid = va_arg(ap, pid_t *);
-        ret = ic_orig_{{ func }}(fn, stack, flags, arg, parent_tid, tls, child_tid);
+        ret = get_ic_orig_{{ func }}()(fn, stack, flags, arg, parent_tid, tls, child_tid);
       }
     }
   }

--- a/src/interceptor/tpl_close_range.c
+++ b/src/interceptor/tpl_close_range.c
@@ -36,20 +36,20 @@
   const unsigned int u_fb_sv_conn = (unsigned int)fb_sv_conn;
   if (first > u_fb_sv_conn || last < u_fb_sv_conn) {
     /* Just go ahead. */
-    ret = ic_orig_close_range(first, last, flags);
+    ret = get_ic_orig_close_range()(first, last, flags);
   } else if (first == u_fb_sv_conn && last == u_fb_sv_conn) {
     /* Wishing to close only fb_sv_conn. Just pretend it succeeded. */
     ret = 0;
   } else if (first == u_fb_sv_conn) {
     /* Need to skip the first fd. */
-    ret = ic_orig_close_range(first + 1, last, flags);
+    ret = get_ic_orig_close_range()(first + 1, last, flags);
   } else if (last == u_fb_sv_conn) {
     /* Need to skip the last fd. */
-    ret = ic_orig_close_range(first, last - 1, flags);
+    ret = get_ic_orig_close_range()(first, last - 1, flags);
   } else {
     /* Need to leave a hole in the range. */
-    int ret1 = ic_orig_close_range(first, u_fb_sv_conn - 1, 0);
-    int ret2 = ic_orig_close_range(u_fb_sv_conn + 1, last, 0);
+    int ret1 = get_ic_orig_close_range()(first, u_fb_sv_conn - 1, 0);
+    int ret2 = get_ic_orig_close_range()(u_fb_sv_conn + 1, last, 0);
     ret = (ret1 == 0 && ret2 == 0) ? 0 : -1;
   }
 ### endblock call_orig

--- a/src/interceptor/tpl_closefrom.c
+++ b/src/interceptor/tpl_closefrom.c
@@ -35,13 +35,13 @@
 
   if (lowfd > fb_sv_conn) {
     /* Just go ahead. */
-    ic_orig_closefrom(lowfd);
+    get_ic_orig_closefrom()(lowfd);
   } else if (lowfd == fb_sv_conn) {
     /* Need to skip the first fd. */
-    ic_orig_closefrom(lowfd + 1);
+    get_ic_orig_closefrom()(lowfd + 1);
   } else {
     /* Need to leave a hole in the range. */
-    ic_orig_close_range(lowfd, fb_sv_conn - 1, 0);
-    ic_orig_closefrom(fb_sv_conn + 1);
+    get_ic_orig_close_range()(lowfd, fb_sv_conn - 1, 0);
+    get_ic_orig_closefrom()(fb_sv_conn + 1);
   }
 ### endblock call_orig

--- a/src/interceptor/tpl_dup2.c
+++ b/src/interceptor/tpl_dup2.c
@@ -32,7 +32,7 @@
     /* In order to make this dup2() or dup3() actually happen to the desired newfd
      * and still be able to talk to the supervisor,
      * we need to move fb_sv_conn to some other file descriptor. */
-    fb_sv_conn_new = TEMP_FAILURE_RETRY(ic_orig_dup(fb_sv_conn));
+    fb_sv_conn_new = TEMP_FAILURE_RETRY(get_ic_orig_dup()(fb_sv_conn));
     if (fb_sv_conn_new < 0) {
       /* This dup() failed, which is very unlikely (out of available fds).
        * There's no hope to succeed with the actual dup2() and still be able to talk
@@ -44,7 +44,7 @@
       return -1;
     }
     /* The communication fd has the close-on-exec flag set, and dup() doesn't copy it. */
-    TEMP_FAILURE_RETRY(ic_orig_fcntl(fb_sv_conn_new, F_SETFD, FD_CLOEXEC));
+    TEMP_FAILURE_RETRY(get_ic_orig_fcntl()(fb_sv_conn_new, F_SETFD, FD_CLOEXEC));
   }
 ### endblock
 
@@ -58,7 +58,7 @@
       /* The actual dup2() failed for whatever reason. Close the dupped connection fd.
        * POSIX says to retry close() on EINTR (e.g. wrap in TEMP_FAILURE_RETRY())
        * but Linux probably disagrees, see #723. */
-      ic_orig_close(fb_sv_conn_new);
+      get_ic_orig_close()(fb_sv_conn_new);
     }
   }
 

--- a/src/interceptor/tpl_exit.c
+++ b/src/interceptor/tpl_exit.c
@@ -38,7 +38,7 @@
   /* Perform the call.
    * This will call the registered atexit / on_exit handlers,
    * including our handle_exit() which will notify the supervisor. */
-  ic_orig_{{ func }}({{ names_str }});
+  get_ic_orig_{{ func }}()({{ names_str }});
 
   /* Make scan-build happy */
   (void)i_locked;

--- a/src/interceptor/tpl_fcntl.c
+++ b/src/interceptor/tpl_fcntl.c
@@ -117,5 +117,5 @@
 ### block call_orig
   /* Treating the optional parameter as 'void *' should work, see #178. */
   void *voidp_arg = va_arg(ap, void *);
-  ret = ic_orig_{{ func }}(fd, cmd, voidp_arg);
+  ret = {{ call_ic_orig_func }}(fd, cmd, voidp_arg);
 ### endblock call_orig

--- a/src/interceptor/tpl_fork.c
+++ b/src/interceptor/tpl_fork.c
@@ -36,7 +36,7 @@
   /* vfork interception would be a bit complicated to implement properly
    * and most of the programs will work properly with fork */
 ###   endif
-  ret = ic_orig_fork();
+  ret = get_ic_orig_fork()();
 ### endblock call_orig
 
 ### block after

--- a/src/interceptor/tpl_ioctl.c
+++ b/src/interceptor/tpl_ioctl.c
@@ -46,5 +46,5 @@
 ### block call_orig
   /* Treating the optional parameter as 'void *' should work, see #178. */
   void *voidp_arg = va_arg(ap, void *);
-  ret = ic_orig_{{ func }}(fd, cmd, voidp_arg);
+  ret = {{ call_ic_orig_func }}(fd, cmd, voidp_arg);
 ### endblock call_orig

--- a/src/interceptor/tpl_open.c
+++ b/src/interceptor/tpl_open.c
@@ -53,8 +53,8 @@
 
 ### block call_orig
 ### if vararg
-  ret = ic_orig_{{ func }}({{ names_str }}, mode);
+  ret = {{ call_ic_orig_func }}({{ names_str }}, mode);
 ### else
-  ret = ic_orig_{{ func }}({{ names_str }});
+  ret = {{ call_ic_orig_func }}({{ names_str }});
 ### endif
 ### endblock call_orig

--- a/src/interceptor/tpl_pipe.c
+++ b/src/interceptor/tpl_pipe.c
@@ -74,7 +74,7 @@
 #ifndef NDEBUG
     received =
 #endif
-        TEMP_FAILURE_RETRY(ic_orig_recvmsg(fb_sv_conn, &msgh, (flags & O_CLOEXEC) ? MSG_CMSG_CLOEXEC : 0));
+        TEMP_FAILURE_RETRY(get_ic_orig_recvmsg()(fb_sv_conn, &msgh, (flags & O_CLOEXEC) ? MSG_CMSG_CLOEXEC : 0));
     assert(received >= 0 && received == (ssize_t)sv_msg_hdr.msg_size);
     assert(fbbcomm_serialized_get_tag((FBBCOMM_Serialized *) sv_msg_buf) == FBBCOMM_TAG_pipe_created);
 
@@ -102,7 +102,7 @@
     }
   } else {
     /* just create the pipe */
-    ret = ic_orig_pipe2(pipefd, flags);
+    ret = get_ic_orig_pipe2()(pipefd, flags);
   }
 ### endblock call_orig
 

--- a/src/interceptor/tpl_popen.c
+++ b/src/interceptor/tpl_popen.c
@@ -73,7 +73,7 @@
       /* No signal between sending the "popen_parent" message and receiving its "popen_fd" response. */
       thread_signal_danger_zone_enter();
 
-      int ret_fileno = ic_orig_fileno(ret);
+      int ret_fileno = get_ic_orig_fileno()(ret);
       FBBCOMM_Builder_popen_parent ic_msg;
       fbbcomm_builder_popen_parent_init(&ic_msg);
       fbbcomm_builder_popen_parent_set_fd(&ic_msg, ret_fileno);
@@ -118,7 +118,7 @@
 #ifndef NDEBUG
       received =
 #endif
-          TEMP_FAILURE_RETRY(ic_orig_recvmsg(fb_sv_conn, &msgh, 0));
+          TEMP_FAILURE_RETRY(get_ic_orig_recvmsg()(fb_sv_conn, &msgh, 0));
       assert(received >= 0 && received == (ssize_t)sv_msg_hdr.msg_size);
       assert(fbbcomm_serialized_get_tag((FBBCOMM_Serialized *) sv_msg_buf) == FBBCOMM_TAG_popen_fd);
       assert(sv_msg_hdr.fd_count == 1);
@@ -135,13 +135,13 @@
         /* Move to the desired slot. Set the O_CLOEXEC bit to the desired value.
          * The fcntl(..., F_SETFL, ...) bits were set by the supervisor. */
         assert(ancillary_fd != ret_fileno);  /* because ret_fileno is still open */
-        if (TEMP_FAILURE_RETRY(ic_orig_dup3(ancillary_fd, ret_fileno, type_flags & O_CLOEXEC))
+        if (TEMP_FAILURE_RETRY(get_ic_orig_dup3()(ancillary_fd, ret_fileno, type_flags & O_CLOEXEC))
             != ret_fileno) {
           assert(0 && "dup3() on the popened fd failed");
         }
         /* POSIX says to retry close() on EINTR (e.g. wrap in TEMP_FAILURE_RETRY())
          * but Linux probably disagrees, see #723. */
-        if (ic_orig_close(ancillary_fd) < 0) {
+        if (get_ic_orig_close()(ancillary_fd) < 0) {
           assert(0 && "close() on the dup3()d popened fd failed");
         }
       }

--- a/src/interceptor/tpl_posix_spawn.c
+++ b/src/interceptor/tpl_posix_spawn.c
@@ -58,7 +58,7 @@
   if (!pid) {
     pid = &tmp_pid;
   }
-  ret = ic_orig_{{ func }}({{ names_str | replace("envp", "env_fixed_up")}});
+  ret = get_ic_orig_{{ func }}()({{ names_str | replace("envp", "env_fixed_up")}});
 ### endblock call_orig
 
 ### block send_msg

--- a/src/interceptor/tpl_pthread_create.c
+++ b/src/interceptor/tpl_pthread_create.c
@@ -36,5 +36,5 @@
   void **routine_and_arg = malloc(2 * sizeof(void *));
   routine_and_arg[0] = start_routine;
   routine_and_arg[1] = arg;
-  ret = ic_orig_pthread_create(thread, attr, pthread_start_routine_wrapper, routine_and_arg);
+  ret = get_ic_orig_pthread_create()(thread, attr, pthread_start_routine_wrapper, routine_and_arg);
 ### endblock call_orig

--- a/src/interceptor/tpl_signal.c
+++ b/src/interceptor/tpl_signal.c
@@ -33,12 +33,12 @@
     sighandler_t new_signal_handler =
         (handler == SIG_IGN || handler == SIG_DFL) ? handler : wrapper_signal_handler_1arg;
     orig_signal_handlers[signum - 1] = (void (*)(void))handler;
-    ret = ic_orig_{{ func }}(signum, new_signal_handler);
+    ret = get_ic_orig_{{ func }}()(signum, new_signal_handler);
     if ((void (*)(int))ret == wrapper_signal_handler_1arg) {
       ret = old_orig_signal_handler;
     }
   } else {
-    ret = ic_orig_{{ func }}(signum, handler);
+    ret = get_ic_orig_{{ func }}()(signum, handler);
   }
 ###   elif func in ['sigaction', 'SYS_sigaction']
   if (signal_is_wrappable(signum)) {
@@ -62,7 +62,7 @@
         wrapped_act.sa_handler = new_signal_handler;
       }
     }
-    ret = ic_orig_{{ func }}(signum, act ? &wrapped_act : NULL, oldact);
+    ret = get_ic_orig_{{ func }}()(signum, act ? &wrapped_act : NULL, oldact);
     if (ret == 0 && oldact != NULL) {
       if (oldact->sa_flags & SA_SIGINFO) {
         /* sa_sigaction, handler called with 3 args */
@@ -77,7 +77,7 @@
       }
     }
   } else {
-    ret = ic_orig_sigaction(signum, act, oldact);
+    ret = get_ic_orig_sigaction()(signum, act, oldact);
   }
 ###   endif
 ### endblock call_orig

--- a/src/interceptor/tpl_skip.c
+++ b/src/interceptor/tpl_skip.c
@@ -20,5 +20,5 @@
 {# This is a standalone template, does not extend tpl.c.              #}
 {# ------------------------------------------------------------------ #}
 ### if gen == 'decl.h'
-#define ic_orig_{{ func }} {{ func }}
+#define get_ic_orig_{{ func }}() {{ func }}
 ### endif

--- a/src/interceptor/tpl_syscall.c
+++ b/src/interceptor/tpl_syscall.c
@@ -54,7 +54,7 @@ long {{ func }} ({{ sig_str }}) {
       long arg7 = va_arg(ap_pass, long);
       long arg8 = va_arg(ap_pass, long);
       va_end(ap_pass);
-      long ret = ic_orig_{{ func }}(number, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+      long ret = get_ic_orig_{{ func }}()(number, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
 
 #ifdef FB_EXTRA_DEBUG
       if (insert_trace_markers) {


### PR DESCRIPTION
Fixes #490.

Co-authored-by: Balint Reczey <balint@balintreczey.hu>

Seems to be slightly faster with `-j1`. I tested with `-j1` because interceptor speed contributes more to wall clock time this way.

```
rbalint@zen:~$ ~/projects/firebuild-infra/perftest/compare_builds.R ~/buildtimes-tmp.csv jammy-v0.2.9.1-5-g0a607b8 jammy-v0.2.9.1-6-g2e142ba
Versions have different run counts, omitting last runs from the longer set.
Time % increase from jammy-v0.2.9.1-5-g0a607b8 to jammy-v0.2.9.1-6-g2e142ba 
comparing 96 run pairs.

     real1             user1              sys1        
 Min.   :-3.2943   Min.   :-3.5897   Min.   :-31.492  
 1st Qu.:-0.8423   1st Qu.:-0.6872   1st Qu.: -4.019  
 Median :-0.2957   Median :-0.2522   Median : -1.037  
 Mean   :-0.3059   Mean   :-0.1695   Mean   : -1.631  
 3rd Qu.: 0.2297   3rd Qu.: 0.2582   3rd Qu.:  2.166  
 Max.   : 2.7992   Max.   : 3.2492   Max.   : 33.721  

Max. real slowdown (%): lzip

                  real1       user1       sys1
 Sum. incr.: -0.1301614 -0.03811003 -0.9587929

     real2             user2              sys2         
 Min.   :-3.6160   Min.   :-4.4248   Min.   :-27.1955  
 1st Qu.:-1.2213   1st Qu.:-1.1901   1st Qu.: -3.8623  
 Median :-0.2993   Median :-0.1862   Median : -0.8128  
 Mean   :-0.3895   Mean   :-0.2408   Mean   : -1.0785  
 3rd Qu.: 0.3282   3rd Qu.: 0.4605   3rd Qu.:  1.2939  
 Max.   : 3.3250   Max.   : 3.5409   Max.   : 18.5732  

Max. real slowdown (%): lz4

                  real2       user2       sys2
 Sum. incr.: -0.1977317 -0.07577487 -0.6476625

     real3             user3                sys3         
 Min.   :-10.762   Min.   :-68.75000   Min.   :-50.0000  
 1st Qu.: -4.628   1st Qu.: -7.34908   1st Qu.: -5.6968  
 Median : -2.644   Median : -3.39071   Median : -0.4786  
 Mean   : -2.552   Mean   : -3.91434   Mean   :  2.2415  
 3rd Qu.: -1.416   3rd Qu.:  0.01083   3rd Qu.:  5.9583  
 Max.   : 20.199   Max.   : 34.61538   Max.   :225.0000  

Max. real slowdown (%): gnome-calculator

                 real3     user3      sys3
 Sum. incr.: -2.201341 -2.109975 -1.755282

Cache size % increase from jammy-v0.2.9.1-5-g0a607b8 to jammy-v0.2.9.1-6-g2e142ba
  cache.size.1         cache.size.2      
 Min.   :-1.7739816   Min.   :-0.392752  
 1st Qu.: 0.0000000   1st Qu.: 0.000000  
 Median : 0.0000000   Median : 0.000000  
 Mean   :-0.0014749   Mean   : 0.044006  
 3rd Qu.: 0.0001859   3rd Qu.: 0.001706  
 Max.   : 0.9185236   Max.   : 0.977807  

             cache.size.1 cache.size.2
 Sum. incr.:   0.00199447   0.03878096

Total time with firebuild (%) in jammy-v0.2.9.1-6-g2e142ba :
         first run second run
real      106.5135   7.741096
user      104.0662   4.709025
sys       146.8068  24.733413
user+sys  107.9932   6.548852
```
