### PR TITLE
interceptor: Treat fallocate() and posix_fallocate() as pwrites

### DIFF
--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -1543,11 +1543,14 @@ generate("int", ["ftruncate64", "SYS_ftruncate64"], "int fd, off64_t len",
          msg_skip_fields=["len"])
 
 # Intercept the fallocate() family
-# TODO(rbalint) handle them as writes
 generate("int", "posix_fallocate", "int fd, off_t offset, off_t len",
-         tpl="once")
+         is_pwrite="true",
+         msg_skip_fields=["offset", "len"],
+         tpl="write")
 generate("int", ["fallocate", "SYS_fallocate"], "int fd, int mode, off_t offset, off_t len",
-         tpl="once")
+         is_pwrite="true",
+         msg_skip_fields=["mode", "offset", "len"],
+         tpl="write")
 
 # Intercept the mkstemp family
 # Note: these update the pathname template in place.


### PR DESCRIPTION
They potentiall change the files in ways similar to pwrites.

This allows shortcutting clang++ in some cases.

Improves #638.