### PR TITLE
Detect inherited file backed fds that are not not seeked to the end in the interceptor

### DIFF
--- a/src/common/fbbcomm.def
+++ b/src/common/fbbcomm.def
@@ -154,6 +154,17 @@
       # The inherited seekable fds that were appended to while shortcutting;
       # the interceptor needs to seek forward in them.
       (ARRAY, "int", "fds_appended_to"),
+      # File backed seekable fds that could be seeked to the end or not.
+      # If they are not at the end the interceptor must send back an inherited_fd_offset message.
+      (ARRAY, "int", "seekable_fds"),
+      # Size of the backed seekable fds as the supervisor knows it.
+      (ARRAY, "int64_t", "seekable_fds_size"),
+    ]),
+
+    # The inherited fd's offset at the start of the process
+    ("inherited_fd_offset", [
+      (REQUIRED, "int", "fd"),
+      (REQUIRED, "int64_t", "offset"),
     ]),
 
     # Those function calls are not handled specially in interceptor lib and

--- a/src/firebuild/execed_process.cc
+++ b/src/firebuild/execed_process.cc
@@ -166,23 +166,9 @@ void ExecedProcess::initialize() {
       if (stat64(file_fd->filename()->c_str(), &st) < 0) {
         disable_shortcutting_only_this("Failed to stat inherited file");
       } else if (S_ISREG(st.st_mode) && is_write(file_fd->flags())) {
-        off_t offset = 0;
-        int flags = 0;
-        if (!get_fdinfo(pid(), file_fd->fd(), &offset, &flags)) {
-          disable_shortcutting_only_this("Failed to get fdinfo for inherited file");
-        } else {
-          // FIXME assert that flags and file_fd->flags() match
-          if (flags & O_APPEND) {
-            /* The current offset won't matter for writes, register the current size instead. */
-            inherited_file.start_offset = st.st_size;
-          } else {
-            if (offset != st.st_size) {
-              disable_shortcutting_only_this(
-                  "Inherited writable non-append fd not seeked to its end");
-            }
-            inherited_file.start_offset = offset;
-          }
-        }
+        /* Assume that the file is seeked to the end. Otherwise the interceptor will
+         * report the offset back. */
+        inherited_file.start_offset = st.st_size;
       }
     }
   }

--- a/src/firebuild/process.cc
+++ b/src/firebuild/process.cc
@@ -1281,6 +1281,24 @@ void Process::handle_seek_in_inherited(const int fd, const bool modify_offset) {
   }
 }
 
+void Process::handle_inherited_fd_offset(const int fd, const int64_t offset) {
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "fd=%d, offset==%ld", fd, offset);
+  FileFD *file_fd = exec_point()->get_fd(fd);
+  if (!file_fd) {
+    exec_point()->disable_shortcutting_bubble_up(
+        "Process reported offset for an intercepted seekable fd which is no known to be open", fd);
+    return;
+  }
+  exec_point()->disable_shortcutting_only_this(
+      "Inherited writable non-append fd not seeked to its end");
+  for (inherited_file_t& inherited_file : exec_point()->inherited_files()) {
+    if (inherited_file.fds[0] == fd) {
+      inherited_file.start_offset = offset;
+      break;
+    }
+  }
+}
+
 void Process::handle_recvmsg_scm_rights(const bool cloexec, const std::vector<int> fds) {
   TRACKX(FB_DEBUG_PROC, 1, 1, Process, this, "cloexec=%s fds=%s", D(cloexec), D(fds));
 

--- a/src/firebuild/process.h
+++ b/src/firebuild/process.h
@@ -538,6 +538,13 @@ class Process {
   void handle_seek_in_inherited(const int fd, const bool modify_offset);
 
   /**
+   * Handle interceptorting the start offset of an inherited file that's not seeked to the end.
+   * @param fd file descriptor
+   * @param offset the offset in the file
+   */
+  void handle_inherited_fd_offset(const int fd, const int64_t offset);
+
+  /**
    * Handle the intercepted process receiving some file descriptors via recv[m]msg() and SCM_RIGHTS
    * @param cloexec the close on exec flag
    * @param fds file descriptors

--- a/src/firebuild/process_fbb_adaptor.h
+++ b/src/firebuild/process_fbb_adaptor.h
@@ -211,6 +211,11 @@ class ProcessFBBAdaptor {
     return 0;
   }
 
+  static int handle(Process *proc, const FBBCOMM_Serialized_inherited_fd_offset *msg) {
+    proc->handle_seek_in_inherited(msg->get_fd(), msg->get_offset());
+    return 0;
+  }
+
   static int handle(Process *proc, const FBBCOMM_Serialized_recvmsg_scm_rights *msg) {
     bool cloexec = msg->get_cloexec();
     std::vector<int> fds = msg->get_fds_as_vector();

--- a/src/firebuild/utils.cc
+++ b/src/firebuild/utils.cc
@@ -99,28 +99,6 @@ ssize_t fb_copy_file_range(int fd_in, loff_t *off_in, int fd_out, loff_t *off_ou
   return len;
 }
 
-bool get_fdinfo(pid_t pid, int fd, off_t *offset, int *flags) {
-  char buf[64];
-  snprintf(buf, sizeof(buf), "/proc/%d/fdinfo/%d", pid, fd);
-  FILE *f = fopen(buf, "r");
-  if (f == NULL) {
-    return false;
-  }
-  bool offset_found = false, flags_found = false;
-  off_t value;
-  while (!(offset_found && flags_found) && fscanf(f, "%63s%ld", buf, &value) == 2) {
-    if (strcmp(buf, "pos:") == 0) {
-      *offset = value;
-      offset_found = true;
-    } else if (strcmp(buf, "flags:") == 0) {
-      *flags = value;
-      flags_found = true;
-    }
-  }
-  fclose(f);
-  return offset_found && flags_found;
-}
-
 unsigned char fixed_dirent_type(const struct dirent* dirent, DIR* dir,
                                 const std::string& dir_path) {
   if (dirent->d_type == DT_UNKNOWN) {

--- a/src/firebuild/utils.h
+++ b/src/firebuild/utils.h
@@ -57,9 +57,6 @@ ssize_t fb_copy_file_range(int fd_in, loff_t *off_in, int fd_out, loff_t *off_ou
       (((a)->tv_nsec)OP((b)->tv_nsec)) :        \
        (((a)->tv_sec)OP((b)->tv_sec)))
 
-/** Get the seek offset and fcntl flags of the given process's given fd. Linux-specific. */
-bool get_fdinfo(pid_t pid, int fd, off_t *offset, int *flags) __attribute__((nonnull(3, 4)));
-
 /** Get fixed up dirent type even if the underlying filesystem did not support d_type. */
 unsigned char fixed_dirent_type(const struct dirent* dirent, DIR* dir,
                                 const std::string& dir_path);

--- a/test/test_file_ops.c
+++ b/test/test_file_ops.c
@@ -228,9 +228,12 @@ int main() {
   }
 
   /* Run part 2. */
+  fd = open("test_nonempty_2.txt", O_WRONLY);
+  lseek(fd, -2, SEEK_END);
   if (system("./test_file_ops_2") != 0) {
     exit(1);
   }
+  close(fd);
 
   /* Cleanup. */
   if (unlink("test_empty_1.txt") != 0) {


### PR DESCRIPTION
Fixes #1118.