### PR TITLE
report: Don't escape "/" in JSON strings

### DIFF
--- a/src/firebuild/report.cc
+++ b/src/firebuild/report.cc
@@ -52,7 +52,6 @@ static std::string escapeJsonString(const std::string& input) {
     switch (*iter) {
       case '\\': ss << "\\\\"; break;
       case '"': ss << "\\\""; break;
-      case '/': ss << "\\/"; break;
       case '\b': ss << "\\b"; break;
       case '\f': ss << "\\f"; break;
       case '\n': ss << "\\n"; break;


### PR DESCRIPTION
Unescaped "/" does not break the JSON format but makes reading the report in text format harder.