### PR TITLE
Intercept seccomp() calls and always return with EINVAL error

### DIFF
--- a/etc/firebuild.conf
+++ b/etc/firebuild.conf
@@ -51,9 +51,7 @@ processes = {
     // hangs, also has its own caching framework
     "gradle",
     // Go has its own caching framework
-    "go",
-    // Man uses seccomp sandboxing which prevents interception after the sandbox is set up.
-    "man"
+    "go"
   ];
 
   // Processes that we could cache and shortcut, but prefer not to (for example

--- a/src/common/fbbcomm.def
+++ b/src/common/fbbcomm.def
@@ -561,6 +561,11 @@
       (REQUIRED, "int", "ret"),
     ]),
 
+    ("seccomp", [
+      # always EINVAL at the moment, since the original call is not called
+      (REQUIRED, "int", "error_no"),
+    ]),
+
     ("exec", [
       # file to execute
       (OPTIONAL, STRING, "file"),

--- a/src/firebuild/message_processor.cc
+++ b/src/firebuild/message_processor.cc
@@ -1176,6 +1176,10 @@ static void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf, uint16_t ack_num,
       /* Ignore gethostname. With a local cache it should not make a difference, while
        * in a shared cache the intention is to use cached results from other machines. */
       break;
+    case FBBCOMM_TAG_seccomp:
+      /* Ignore seccomp(). The interposer always returns EINVAL error to keep interception
+       * working. This breaks sandboxing, but builds can run arbitrary commands anyway. */
+      break;
     case FBBCOMM_TAG_fb_debug:
     case FBBCOMM_TAG_fb_error:
     case FBBCOMM_TAG_fchownat:

--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -2048,6 +2048,15 @@ generate("mode_t", ["umask", "SYS_umask"], "mode_t mask",
          send_msg_on_error=False)
 # Note: getumask is gone since glibc 2.24
 
+# Pretend that seccomp() is not implemented.
+# This allows interception of a few commands that otherwise would use seccomp sandboxing, such as man
+# and friends.
+generate("int", "SYS_seccomp", "unsigned int operation, unsigned int flags, void *args",
+         msg_skip_fields=["operation", "flags", "args"],
+         msg="seccomp",
+         call_orig_lines=["(void)operation; (void)flags; (void)args;",
+                          "errno = EINVAL; ret =  -1;"])
+
 # FIXME {get,set,p}rlimit
 
 # User and group stuff


### PR DESCRIPTION
Also allow intercepting man again since seccomp() calls won't crash it anymore under interception.

Improves #312.