### PR TITLE
supervisor: Add default quirk to ignore successful statfs() and fstatfs() calls

### DIFF
--- a/etc/firebuild.conf
+++ b/etc/firebuild.conf
@@ -122,6 +122,9 @@ quirks = [
   // Since the internal make is started in /tmp the ignore-tmp-listing quirk needs to
   // be enabled as well to shortcut lto-wrapper.
   "lto-wrapper",
+  // dot (via libfontconfig) and other commands call (f)stafs() which don't impact the output.
+  // Ignore those calls to allow shortcutting such processes.
+  "ignore-statfs",
   // Guess if a command parameter is a file and include the hash of the file in the process fingerprint.
   // This typically speeds up shortcutting, but may prevent shortcutting when the files passed to a command
   // as parameters already exist and their content would not be read by the command.

--- a/src/firebuild/config.cc
+++ b/src/firebuild/config.cc
@@ -322,6 +322,8 @@ void read_config(libconfig::Config *cfg, const char *custom_cfg_file,
         quirks |= FB_QUIRK_LTO_WRAPPER;
       } else if (quirk == "ignore-time-queries") {
         quirks |= FB_QUIRK_IGNORE_TIME_QUERIES;
+      } else if (quirk == "ignore-statfs") {
+        quirks |= FB_QUIRK_IGNORE_STATFS;
       } else if (quirk == "guess-file-params") {
         quirks |= FB_QUIRK_GUESS_FILE_PARAMS;
       } else {

--- a/src/firebuild/config.h
+++ b/src/firebuild/config.h
@@ -60,6 +60,7 @@ extern int quirks;
 #define FB_QUIRK_LTO_WRAPPER         0x02
 #define FB_QUIRK_GUESS_FILE_PARAMS   0x04
 #define FB_QUIRK_IGNORE_TIME_QUERIES 0x08
+#define FB_QUIRK_IGNORE_STATFS       0x10
 
 void read_config(libconfig::Config *cfg, const char *custom_cfg_file,
                  const std::list<std::string>& config_strings);


### PR DESCRIPTION
This allows shortcutting Doxygen documentation generation among other commands.