### PR TITLE
ci: Split running tests with valgrind to a separate job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         key: build-on-ubuntu-lts
     - name: install-deps
       run: |
-        sudo eatmydata apt-get -y install $BUILD_DEPS $TEST_DEPS doxygen valgrind lcov
+        sudo eatmydata apt-get -y install $BUILD_DEPS $TEST_DEPS doxygen lcov
     - name: build-out-of-tree
       run: |
         export PATH=/usr/lib/ccache:$PATH
@@ -52,7 +52,6 @@ jobs:
     - name: test
       run: |
         make check
-        test/close_fds_exec make valgrind-check
     - name: coverage
       # tests don't run with out of tree builds at the moment
       run: |
@@ -61,6 +60,41 @@ jobs:
         cmake -DCOVERAGE=1 .
         make -j2 check coverage-info
         [ $(echo "$(make coverage-info | grep '^[\.0-9]*$') >= 73" | bc) = 1 ]
+    - name: save-cached-debs
+      run: |
+        rm -f ~/.cache/debs/*
+        cp /var/cache/apt/archives/*deb ~/.cache/debs/
+
+  test-with-valgrind:
+    needs: style-checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/cache@v3
+      with:
+        path: ~/.cache/debs
+        key: test-with-valgrind-debs-${{ needs.style-checks.outputs.week }}
+    # TODO: This and saving the debs can be dropped and and the debs can be saved directly like in docker
+    # when https://github.com/actions/cache/issues/324 gets fixed
+    - name: restore-cached-debs
+      run: |
+        [ -d ~/.cache/debs ] && sudo cp ~/.cache/debs/* /var/cache/apt/archives/ || mkdir -p ~/.cache/debs
+    - uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: test-with-valgrind
+    - name: install-deps
+      run: |
+        sudo eatmydata apt-get -y install $BUILD_DEPS $TEST_DEPS valgrind
+    - name: build-in-tree
+      run: |
+        export PATH=/usr/lib/ccache:$PATH
+        cmake -DWITH_JEMALLOC=OFF -DCMAKE_BUILD_TYPE=Debug .
+        make -j2
+    - name: test
+      run: |
+        make -j3 close_fds_exec
+        test/close_fds_exec make valgrind-check
     - name: save-cached-debs
       run: |
         rm -f ~/.cache/debs/*

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,10 +9,11 @@ add_custom_command(
   COMMENT "Generating fbbtest files")
 
 add_custom_target(fbbtest_gen_files ALL DEPENDS fbbtest.cc fbbtest.h fbbtest_decode.c)
+add_custom_target(check-bins)
 
 function(add_test_binary TEST_BINARY)
   add_executable("${TEST_BINARY}" EXCLUDE_FROM_ALL "${TEST_BINARY}.c")
-  add_dependencies(check "${TEST_BINARY}")
+  add_dependencies(check-bins "${TEST_BINARY}")
 endfunction()
 
 foreach(TESTFILE integration.bats test_parallel_make.Makefile test_symbols)
@@ -69,7 +70,7 @@ add_custom_target(check-deps)
 add_dependencies(check-deps fbb_test)
 add_dependencies(check-deps firebuild)
 add_dependencies(check-deps firebuild-bin)
-add_dependencies(check check-deps)
-add_dependencies(valgrind-check check-deps)
+add_dependencies(check check-deps check-bins)
+add_dependencies(valgrind-check check-deps check-bins)
 
 add_test(test-symbols ./test_symbols ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
make valgrind-check was the slowest part of the build-on-ubuntu-lts job taking around half of its time. With valgrind-check split out the whole CI run should finish in around half time.