### PR TITLE
supervisor: Ignore missing configuration settings

### DIFF
--- a/src/common/firebuild_common.c
+++ b/src/common/firebuild_common.c
@@ -50,7 +50,9 @@ static int cmp_cstring_view(const void *p1, const void *p2) {
 }
 
 void cstring_view_array_sort(cstring_view_array *array) {
-  qsort(array->p, array->len, sizeof(cstring_view), cmp_cstring_view);
+  if (array->p) {
+    qsort(array->p, array->len, sizeof(cstring_view), cmp_cstring_view);
+  }
 }
 
 /* The string array needs to allocate more space to append a new entry. */

--- a/src/firebuild/execed_process_cacher.cc
+++ b/src/firebuild/execed_process_cacher.cc
@@ -208,9 +208,13 @@ ExecedProcessCacher::ExecedProcessCacher(bool no_store,
     no_store_(no_store), no_fetch_(no_fetch),
     envs_skip_(), ignore_locations_hash_(), fingerprints_(), fingerprint_msgs_(),
     cache_dir_(cache_dir) {
-  const libconfig::Setting& envs_skip = cfg->getRoot()["env_vars"]["fingerprint_skip"];
-  for (int i = 0; i < envs_skip.getLength(); i++) {
-    envs_skip_.insert(envs_skip[i].c_str());
+  try {
+    const libconfig::Setting& envs_skip = cfg->getRoot()["env_vars"]["fingerprint_skip"];
+    for (int i = 0; i < envs_skip.getLength(); i++) {
+      envs_skip_.insert(envs_skip[i].c_str());
+    }
+  } catch(libconfig::SettingNotFoundException&) {
+    /* Configuration setting may be missing. This is OK. */
   }
 #ifdef XXH_INLINE_ALL
   XXH3_state_t state_struct;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,7 +16,7 @@ function(add_test_binary TEST_BINARY)
   add_dependencies(check-bins "${TEST_BINARY}")
 endfunction()
 
-foreach(TESTFILE integration.bats test_parallel_make.Makefile test_symbols)
+foreach(TESTFILE empty-config.conf integration.bats test_parallel_make.Makefile test_symbols)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/${TESTFILE}" "${CMAKE_CURRENT_BINARY_DIR}/${TESTFILE}" COPYONLY)
 endforeach()
 

--- a/test/empty-config.conf
+++ b/test/empty-config.conf
@@ -1,0 +1,9 @@
+// (Almost) empty configuration file
+
+version = 1.0;
+
+// Those settings are changed in ./run-firebuild, thus they are needed to not break the test
+env_vars = {
+  pass_through = [ "PATH", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"];
+};
+ignore_locations = [];

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -11,6 +11,12 @@ setup() {
   echo "$result" | grep -q "in case of failure"
 }
 
+@test "empty-config" {
+  result=$(./run-firebuild -c empty-config.conf -- ls integration.bats)
+    assert_streq "$result" "integration.bats"
+    assert_streq "$(strip_stderr stderr)" ""
+}
+
 @test "bash -c ls" {
   for i in 1 2; do
     result=$(./run-firebuild -o 'processes.dont_shortcut -= "ls"'  -- bash -c "ls integration.bats")


### PR DESCRIPTION
Fixes crashes when upgrading to new Firebuild version and keeping the old configuration file.