### PR TITLE
supervisor: Rename system_locations to read_only_locations

### DIFF
--- a/etc/firebuild.conf
+++ b/etc/firebuild.conf
@@ -11,7 +11,7 @@ env_vars = {
   fingerprint_skip = [ "MAKE_TERMOUT", "MAKE_TERMERR" ];
 
   // The folloving environment variables are pre-set to the values configured below.
-  // Note that FB_SOCKET, FB_SYSTEM_LOCATIONS, FB_IGNORE_LOCATIONS and LD_PRELOAD
+  // Note that FB_SOCKET, FB_READ_ONLY_LOCATIONS, FB_IGNORE_LOCATIONS and LD_PRELOAD
   // (DYLD_INSERT_LIBRARIES and DYLD_FORCE_FLAT_NAMESPACE on OS X)
   // are also set by firebuild internally.
   // The variables should be in "NAME=value" format.
@@ -104,9 +104,9 @@ ignore_locations = [
 ];
 
 // These files, directores, or any location under these directories assumed to be
-// system files not changing while firebuild is running. Opening a file with
+// read-only files not changing while firebuild is running. Opening a file with
 // those prefixes does not delay program execution while the file hash is saved.
-system_locations = [
+read_only_locations = [
   "/bin", "/etc", "/lib", "/lib32", "/libx32", "/lib64", "/opt", "/proc/sys", "/sbin", "/snap", "/usr"
 ];
 

--- a/src/firebuild/config.h
+++ b/src/firebuild/config.h
@@ -35,7 +35,7 @@ namespace firebuild {
 extern libconfig::Config * cfg;
 
 extern cstring_view_array ignore_locations;
-extern cstring_view_array system_locations;
+extern cstring_view_array read_only_locations;
 extern ExeMatcher* shortcut_allow_list_matcher;
 extern ExeMatcher* dont_shortcut_matcher;
 extern ExeMatcher* dont_intercept_matcher;

--- a/src/firebuild/execed_process_cacher.cc
+++ b/src/firebuild/execed_process_cacher.cc
@@ -682,7 +682,7 @@ void ExecedProcessCacher::store(ExecedProcess *proc) {
       const auto filename = pair.first;
       const FileUsage* fu = pair.second;
 
-      if (filename->is_in_system_location() == (i == 0)) {
+      if (filename->is_in_read_only_location() == (i == 0)) {
         continue;
       }
 
@@ -1557,7 +1557,7 @@ bool ExecedProcessCacher::is_entry_usable(uint8_t* entry_buf,
     auto file = reinterpret_cast<const FBBSTORE_Serialized_file *>(inputs->get_path_at(i));
     const auto path {FileName::Get(file->get_path(), file->get_path_len())};
     const FileInfo query {file_to_file_info(file)};
-    if (query.type() == ISREG && path->is_in_system_location() &&
+    if (query.type() == ISREG && path->is_in_read_only_location() &&
         !hash_cache->file_info_matches(path, query) &&
         hash_cache->file_info_matches(path, FileInfo(EXIST))) {
       FB_DEBUG(FB_DEBUG_CACHING, "Cache entry expects a system file that has changed: " + d(path));

--- a/src/firebuild/file_name.h
+++ b/src/firebuild/file_name.h
@@ -44,7 +44,7 @@ class FileName {
   FileName(const FileName& other)
       : name_(reinterpret_cast<const char *>(malloc(other.length_ + 1))),
         length_(other.length_), in_ignore_location_(other.in_ignore_location_),
-        in_system_location_(other.in_system_location_) {
+        in_read_only_location_(other.in_read_only_location_) {
     memcpy(const_cast<char*>(name_), other.name_, other.length_ + 1);
   }
   const char * c_str() const {return name_;}
@@ -93,7 +93,7 @@ class FileName {
   static const FileName* GetParentDir(const char * const name, ssize_t length);
 
   bool is_in_ignore_location() const {return in_ignore_location_;}
-  bool is_in_system_location() const {return in_system_location_;}
+  bool is_in_read_only_location() const {return in_read_only_location_;}
 
   std::string without_dirs() const {
     // TODO(rbalint) use std::string::ends_with when we switch to c++20
@@ -109,7 +109,7 @@ class FileName {
  private:
   FileName(const char * const name, size_t length, bool copy_name)
       : name_(copy_name ? reinterpret_cast<const char *>(malloc(length + 1)) : name),
-        length_(length), in_ignore_location_(false), in_system_location_(false) {
+        length_(length), in_ignore_location_(false), in_read_only_location_(false) {
     if (copy_name) {
       memcpy(const_cast<char*>(name_), name, length);
       const_cast<char*>(name_)[length] = '\0';
@@ -126,7 +126,7 @@ class FileName {
   const char * const name_;
   const uint32_t length_;
   const bool in_ignore_location_;
-  const bool in_system_location_;
+  const bool in_read_only_location_;
   static std::unordered_set<FileName, FileNameHasher>* db_;
   static tsl::hopscotch_map<const FileName*, XXH128_hash_t>* hash_db_;
   /** Number of FileOFDs open for writing referencing this file. */
@@ -171,7 +171,7 @@ struct FileNameLess {
 };
 
 extern cstring_view_array ignore_locations;
-extern cstring_view_array system_locations;
+extern cstring_view_array read_only_locations;
 
 inline const FileName* FileName::Get(const char * const name, ssize_t length) {
   FileName tmp_file_name(name, (length == -1) ? strlen(name) : length, false);
@@ -184,8 +184,8 @@ inline const FileName* FileName::Get(const char * const name, ssize_t length) {
   } else {
     *const_cast<bool*>(&tmp_file_name.in_ignore_location_) =
         tmp_file_name.is_at_locations(&ignore_locations);
-    *const_cast<bool*>(&tmp_file_name.in_system_location_) =
-        tmp_file_name.is_at_locations(&system_locations);
+    *const_cast<bool*>(&tmp_file_name.in_read_only_location_) =
+        tmp_file_name.is_at_locations(&read_only_locations);
     /* Not found, add a copy to the set. */
     return &*db_->insert(tmp_file_name).first;
   }

--- a/src/interceptor/env.c
+++ b/src/interceptor/env.c
@@ -94,7 +94,7 @@ static bool ld_preload_needs_fixup(char **env) {
 }
 
 bool env_needs_fixup(char **env) {
-  /* FB_SYSTEM_LOCATIONS and FB_IGNORE_LOCATIONS are not fixed up because they are not needed
+  /* FB_READ_ONLY_LOCATIONS and FB_IGNORE_LOCATIONS are not fixed up because they are not needed
    * for correctness, just for improving performance a bit. */
   return (fb_insert_trace_markers_needs_fixup(env) ||
           fb_socket_needs_fixup(env) ||

--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -398,7 +398,7 @@ generate("int", ["creat", "creat64", "SYS_creat"], "const char *pathname, mode_t
 # Intercept fopen
 def open_ack_condition(msg):
   return "success " \
-    "&& !is_path_at_locations(fbbcomm_builder_" + msg + "_get_pathname(&ic_msg), fbbcomm_builder_" + msg + "_get_pathname_len(&ic_msg), &system_locations) " \
+    "&& !is_path_at_locations(fbbcomm_builder_" + msg + "_get_pathname(&ic_msg), fbbcomm_builder_" + msg + "_get_pathname_len(&ic_msg), &read_only_locations) " \
     "&& !is_path_at_locations(fbbcomm_builder_" + msg + "_get_pathname(&ic_msg), fbbcomm_builder_" + msg + "_get_pathname_len(&ic_msg), &ignore_locations)"
 
 # Note: confusingly open()'s and fopen()'s manual uses the word "mode" for something completely different.

--- a/src/interceptor/intercept.c
+++ b/src/interceptor/intercept.c
@@ -75,12 +75,12 @@ pthread_once_t ic_init_control = PTHREAD_ONCE_INIT;
 bool ic_init_done = false;
 
 /** System locations to not ask ACK for when opening them, as set in the environment variable. */
-char system_locations_env_buf[4096];
+char read_only_locations_env_buf[4096];
 
 /** Ignore locations to not ask ACK for when opening them, as set in the environment variable. */
 char ignore_locations_env_buf[4096];
 
-STATIC_CSTRING_VIEW_ARRAY(system_locations, 32);
+STATIC_CSTRING_VIEW_ARRAY(read_only_locations, 32);
 STATIC_CSTRING_VIEW_ARRAY(ignore_locations, 32);
 
 bool intercepting_enabled = true;
@@ -870,8 +870,8 @@ static void fb_ic_init() {
     insert_trace_markers = true;
   }
 
-  store_locations("FB_SYSTEM_LOCATIONS", &system_locations, system_locations_env_buf,
-                  sizeof(system_locations_env_buf));
+  store_locations("FB_READ_ONLY_LOCATIONS", &read_only_locations, read_only_locations_env_buf,
+                  sizeof(read_only_locations_env_buf));
   store_locations("FB_IGNORE_LOCATIONS", &ignore_locations, ignore_locations_env_buf,
                   sizeof(ignore_locations_env_buf));
 
@@ -953,10 +953,10 @@ static void fb_ic_init() {
 
   for (char** cursor = env; *cursor != NULL; cursor++) {
     const char *fb_socket = "FB_SOCKET=";
-    const char *fb_system_locations = "FB_SYSTEM_LOCATIONS=";
+    const char *fb_read_only_locations = "FB_READ_ONLY_LOCATIONS=";
     const char *fb_ignore_locations = "FB_IGNORE_LOCATIONS=";
     if (strncmp(*cursor, fb_socket, strlen(fb_socket)) != 0 &&
-        strncmp(*cursor, fb_system_locations, strlen(fb_system_locations)) != 0 &&
+        strncmp(*cursor, fb_read_only_locations, strlen(fb_read_only_locations)) != 0 &&
         strncmp(*cursor, fb_ignore_locations, strlen(fb_ignore_locations)) != 0) {
       env_copy[env_copy_len++] = *cursor;
     }

--- a/src/interceptor/intercept.h
+++ b/src/interceptor/intercept.h
@@ -238,7 +238,7 @@ extern char env_ld_library_path[IC_PATH_BUFSIZE];
 extern bool insert_trace_markers;
 
 /** System and ignore locations to not ask ACK for when opening them. */
-extern cstring_view_array system_locations;
+extern cstring_view_array read_only_locations;
 extern cstring_view_array ignore_locations;
 
 /** Insert debug message */

--- a/src/interceptor/tpl_open.c
+++ b/src/interceptor/tpl_open.c
@@ -35,7 +35,7 @@
 ### endif
 ### set after_lines = ["if (i_am_intercepting && success) clear_notify_on_read_write_state(ret);"]
 ### set send_ret_on_success=True
-### set ack_condition = "success && !is_path_at_locations(fbbcomm_builder_" + msg + "_get_pathname(&ic_msg), fbbcomm_builder_" + msg + "_get_pathname_len(&ic_msg), &system_locations) && !is_path_at_locations(fbbcomm_builder_" + msg + "_get_pathname(&ic_msg), fbbcomm_builder_" + msg + "_get_pathname_len(&ic_msg), &ignore_locations)"
+### set ack_condition = "success && !is_path_at_locations(fbbcomm_builder_" + msg + "_get_pathname(&ic_msg), fbbcomm_builder_" + msg + "_get_pathname_len(&ic_msg), &read_only_locations) && !is_path_at_locations(fbbcomm_builder_" + msg + "_get_pathname(&ic_msg), fbbcomm_builder_" + msg + "_get_pathname_len(&ic_msg), &ignore_locations)"
 
 ### block before
 {{ super() }}


### PR DESCRIPTION
The read-only property is why those files are handled differently and the rename encourages users to add their own locations for example for out-of-tree builds or separately installed dependencies.

Improves #561.