### PR TITLE
Use firebuild's caching logic by default instead of ccache's when the intercepted build uses ccache

### DIFF
--- a/etc/firebuild.conf
+++ b/etc/firebuild.conf
@@ -15,7 +15,12 @@ env_vars = {
   // (DYLD_INSERT_LIBRARIES and DYLD_FORCE_FLAT_NAMESPACE on OS X)
   // are also set by firebuild internally.
   // The variables should be in "NAME=value" format.
-  preset = [];
+  preset = [
+    // Make ccache call the original compiler. This allows firebuild rather than ccache
+    // cache the build results. To enable ccache's caching in firebuild-intercepted builds
+    // don't set CCACHE_DISABLE=1 and add "ccache" to the processes.dont_shortcut list.
+    "CCACHE_DISABLE=1"
+  ];
 };
 
 processes = {
@@ -47,8 +52,10 @@ processes = {
   dont_intercept = [
     // starts a daemon and causes deadlock with interception enabled
     "fakeroot",
-    // similar build accelerator which is unlikely to be shortcut efficiently
-    "ccache",
+    // Similar build accelerator which is unlikely to be shortcut efficiently.
+    // Interception is enabled because firebuild also sets CCACHE_DISABLE=1 by default thus
+    // ccache will just call the original compiler.
+    // "ccache",
     // hangs, also has its own caching framework
     "gradle",
     // Go has its own caching framework

--- a/src/firebuild/config.cc
+++ b/src/firebuild/config.cc
@@ -54,6 +54,7 @@ ExeMatcher* dont_shortcut_matcher = nullptr;
 ExeMatcher* dont_intercept_matcher = nullptr;
 ExeMatcher* skip_cache_matcher = nullptr;
 tsl::hopscotch_set<std::string>* shells = nullptr;
+bool ccache_disabled = false;
 /** Store results of processes consuming more CPU time (system + user) in microseconds than this. */
 int64_t min_cpu_time_u = 0;
 int shortcut_tries = 0;
@@ -436,6 +437,9 @@ char** get_sanitized_env(libconfig::Config *cfg, const char *fb_conn_string,
       } else {
         const std::string var_name = str.substr(0, eq_pos);
         env[var_name] = str.substr(eq_pos + 1);
+        if (str == "CCACHE_DISABLE=1") {
+          ccache_disabled = true;
+        }
         FB_DEBUG(FB_DEBUG_PROC, " " + var_name + "=" + env[var_name]);
       }
     }

--- a/src/firebuild/config.h
+++ b/src/firebuild/config.h
@@ -41,6 +41,7 @@ extern ExeMatcher* dont_shortcut_matcher;
 extern ExeMatcher* dont_intercept_matcher;
 extern ExeMatcher* skip_cache_matcher;
 extern tsl::hopscotch_set<std::string>* shells;
+extern bool ccache_disabled;
 
 /** Store results of processes consuming more CPU time (system + user) in microseconds than this. */
 extern int64_t min_cpu_time_u;

--- a/test/test_helper.bash.in
+++ b/test/test_helper.bash.in
@@ -1,6 +1,6 @@
 #!/bin/bash
 export @CMAKE_TARGET_LD_LIBRARY_PATH@=@CMAKE_BINARY_DIR@/src/interceptor:$@CMAKE_TARGET_LD_LIBRARY_PATH@
-export PATH=@CMAKE_BINARY_DIR@/src/firebuild:${PATH/ccache/ccache-DISABLED/}
+export PATH=@CMAKE_BINARY_DIR@/src/firebuild:$PATH
 export FIREBUILD_CACHE_DIR=@CMAKE_CURRENT_BINARY_DIR@/test_cache_dir
 export GCOV_PREFIX=@CMAKE_BINARY_DIR@/gcov
 export GCOV_PREFIX_STRIP=$(echo @CMAKE_BINARY_DIR@ | tr -dc / | wc -c)

--- a/tools/rebuild-self
+++ b/tools/rebuild-self
@@ -14,7 +14,6 @@ cd ${build_dir}-first-build
 cmake ..
 make all
 cd test
-export PATH="${PATH/ccache/ccache-DISABLED/}"
 mkdir ../../$build_dir
 ./run-firebuild -- env -C ../../$build_dir cmake ..
 ./run-firebuild -- make -C ../../$build_dir clean


### PR DESCRIPTION
It is faster than not intercepting ccache and letting it work.