### PR TITLE
supervisor: Don't store hash of "deps" directory listing for rustc

### DIFF
--- a/src/firebuild/execed_process_cacher.cc
+++ b/src/firebuild/execed_process_cacher.cc
@@ -719,8 +719,9 @@ void ExecedProcessCacher::store(ExecedProcess *proc) {
           in_path_notexist.push_back({filename->c_str(), filename->length()});
           break;
         case ISDIR:
-          if (fu->initial_state().hash_known() && quirks & FB_QUIRK_IGNORE_TMP_LISTING
-              && filename == tmpdir) {
+          if (fu->initial_state().hash_known()
+              && ((quirks & FB_QUIRK_IGNORE_TMP_LISTING && filename == tmpdir)
+                  || (proc->args()[0] == "rustc" && filename->without_dirs() == "deps"))) {
             FileInfo no_hash_initial_state(fu->initial_state());
             no_hash_initial_state.set_hash(nullptr);
             add_file(&in_path, filename, no_hash_initial_state);

--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -2058,7 +2058,7 @@ skip("timer_create", "SYS_timer_create", "timer_delete", "SYS_timer_delete", "ti
 skip("timer_settime", "SYS_timer_settime", "SYS_timer_settime_time64", "timer_gettime", "SYS_timer_gettime", "SYS_timer_gettime_time64")
 
 # Getting high entropy randomness should disable shortcutting
-generate("ssize_t", "getrandom", "void* buf, size_t buflen, unsigned int flags",
+generate("ssize_t", ["getrandom", "SYS_getrandom"], "void* buf, size_t buflen, unsigned int flags",
          platforms=['linux'],
          msg_skip_fields = ["buf", "buflen"])
 generate("int", "getentropy", "void* buffer, size_t length",


### PR DESCRIPTION
The deps directory keeps changing during the build and hashing the file listing causes very low hit rate. The dependency files used by rustc are still cached, thus skipping the directory listing does not cause false positive hits.

Fixes #1158.