### PR TITLE
supervisor: Allow configuring maximal cache entry size

### DIFF
--- a/etc/firebuild.conf
+++ b/etc/firebuild.conf
@@ -172,3 +172,8 @@ shortcut_tries = 20;
 // garbage collection is started to remove the unusable cache entries first, then the last
 // recently used ones until the cache size is decreased to at least 20% under the limit.
 max_cache_size = 5.0
+
+// Maximum size of one cache entry in MB.
+// This includes the size of all outputs to be replayed when using the cache entry for shortcutting
+// and the entry's size.
+max_entry_size = 250.0

--- a/src/firebuild/config.cc
+++ b/src/firebuild/config.cc
@@ -59,6 +59,7 @@ bool ccache_disabled = false;
 int64_t min_cpu_time_u = 0;
 int shortcut_tries = 0;
 int64_t max_cache_size = 0;
+uint64_t max_entry_size = 0;
 int quirks = 0;
 
 /**
@@ -315,6 +316,18 @@ void read_config(libconfig::Config *cfg, const char *custom_cfg_file,
         /* Fix up negative numbers. */
         max_cache_size = 0;
       }
+    }
+  }
+
+  if (cfg->exists("max_entry_size")) {
+    libconfig::Setting& max_entry_size_cfg = cfg->getRoot()["max_entry_size"];
+    if (max_entry_size_cfg.isNumber()) {
+      double max_entry_size_mb = max_entry_size_cfg;
+      if (max_entry_size_mb < 0) {
+        /* Fix up negative numbers. */
+        max_entry_size_mb = 0;
+      }
+      max_entry_size = max_entry_size_mb * 1000000;
     }
   }
 

--- a/src/firebuild/config.h
+++ b/src/firebuild/config.h
@@ -56,6 +56,11 @@ extern int shortcut_tries;
  */
 extern int64_t max_cache_size;
 
+/**
+ * Maximum size of a single cache entry including the referenced objs.
+ */
+extern uint64_t max_entry_size;
+
 /** Enabled quirks represented as flags. See "quirks" in etc/firebuild.conf. */
 extern int quirks;
 #define FB_QUIRK_IGNORE_TMP_LISTING  0x01

--- a/src/firebuild/hash_cache.h
+++ b/src/firebuild/hash_cache.h
@@ -98,15 +98,16 @@ class HashCache {
   /**
    * Return the hash of a regular file. Also store this file in the blob cache.
    *
-   * @param path         file's path
-   * @param max_writers  maximum allowed number of writers to this file
-   * @param[out] hash    hash to retrive/calculate
-   * @param fd           if >= 0 then read the file from there
-   * @param stat_ptr     optionally the file's parameters already stat()'ed
-   * @return             false if not a regular file or directory
+   * @param path              file's path
+   * @param max_writers       maximum allowed number of writers to this file
+   * @param[out] hash         hash to retrive/calculate
+   * @param[out] stored_bytes bytes stored to the blob cache
+   * @param fd                if >= 0 then read the file from there
+   * @param stat_ptr          optionally the file's parameters already stat()'ed
+   * @return                  false if not a regular file or directory
    */
-  bool store_and_get_hash(const FileName* path, int max_writers, Hash *hash, int fd,
-                          const struct stat64 *stat_ptr);
+  bool store_and_get_hash(const FileName* path, int max_writers, Hash *hash, off_t* stored_bytes,
+                          int fd, const struct stat64 *stat_ptr);
 
   /**
    * Check if the given FileInfo query matches the file system.
@@ -155,12 +156,13 @@ class HashCache {
    * @param fd                    if >= 0 then read the file from there
    * @param stat_ptr              optionally the file's parameters already stat()'ed
    * @param store                 whether to store the file in the blob cache
+   * @param[out] stored_bytes     bytes stored to the blob cache
    * @param skip_statinfo_update  assume that the stat info is up-to-date
    * @return                      the requested information about the file
    */
   const HashCacheEntry* get_entry_with_statinfo_and_hash(const FileName* path, int max_writers,
                                                          int fd, const struct stat64 *stat_ptr,
-                                                         bool store,
+                                                         bool store, off_t* stored_bytes,
                                                          bool skip_statinfo_update = false);
 
   /**

--- a/src/firebuild/obj_cache.h
+++ b/src/firebuild/obj_cache.h
@@ -69,11 +69,13 @@ class ObjCache {
    *
    * @param key The key
    * @param entry The entry to serialize and store
+   * @param stored_blob_bytes Total size of blobs referenced by this obj
    * @param debug_key Optionally the key as pb for debugging purposes
    * @return Whether succeeded
    */
   bool store(const Hash &key,
              const FBBSTORE_Builder * const entry,
+             off_t stored_blob_bytes,
              const FBBFP_Serialized * const debug_key);
   /**
    * Retrieve an entry from the obj-cache.

--- a/src/firebuild/pipe_recorder.cc
+++ b/src/firebuild/pipe_recorder.cc
@@ -127,7 +127,7 @@ void PipeRecorder::add_data_from_regular_fd(int fd_in, loff_t off_in, ssize_t le
   assert_cmp(offset_, >, 0);
 }
 
-bool PipeRecorder::store(bool *is_empty_out, Hash *key_out) {
+bool PipeRecorder::store(bool *is_empty_out, Hash *key_out, off_t* stored_bytes) {
   TRACKX(FB_DEBUG_PIPE, 1, 1, PipeRecorder, this, "");
 
   assert(!deactivated_);
@@ -140,6 +140,7 @@ bool PipeRecorder::store(bool *is_empty_out, Hash *key_out) {
     ret = blob_cache->move_store_file(filename_, fd_, offset_, key_out);
     /* Note: move_store_file() closed the fd_. */
     fd_ = -1;
+    *stored_bytes = ret ? offset_ : 0;
   } else {
     /* No data was seen at all. */
     *is_empty_out = true;

--- a/src/firebuild/pipe_recorder.h
+++ b/src/firebuild/pipe_recorder.h
@@ -169,7 +169,7 @@ class PipeRecorder {
    * Set the recorder to abandoned state.
    * Returns false in case of failure.
    */
-  bool store(bool *is_empty_out, Hash *key_out);
+  bool store(bool *is_empty_out, Hash *key_out, off_t* stored_bytes);
   /** Close the backing fd, drop the data that was written so far. Set to deactivated state. */
   void deactivate();
   /** Close the backing fd, drop the data that was written so far. Set to abandoned state. */

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -339,6 +339,16 @@ setup() {
   done
 }
 
+@test "max entry size" {
+  result=$(./run-firebuild -d caching -o 'processes.skip_cache -= "dd"' dd if=/dev/zero of=foo bs=1MB count=251)
+  assert_streq "$result" ""
+  assert_streq "$(strip_stderr stderr | grep max_entry)" "FIREBUILD: Could not store blob in cache because it would exceed max_entry_size"
+  result=$(./run-firebuild -d caching -o 'processes.skip_cache -= "dd"' -o 'max_entry_size = 0.0042' dd if=/dev/zero of=foo bs=4k count=1)
+  assert_streq "$result" ""
+  assert_streq "$(strip_stderr stderr | grep max_entry)" "FIREBUILD: Could not store entry in cache because it would exceed max_entry_size"
+  rm -f foo
+}
+
 @test "gc" {
   rm -f foo
   result=$(./run-firebuild -d cache -- bash -c 'echo foo > foo')


### PR DESCRIPTION
Set the default to 250MB.