### PR TITLE
Report improvements

### DIFF
--- a/src/firebuild/file_name.cc
+++ b/src/firebuild/file_name.cc
@@ -65,16 +65,22 @@ void FileName::open_for_writing(Process* proc) const {
       /* A different process opened the file for writing. */
       ExecedProcess* common_ancestor =
           proc->exec_point()->common_exec_ancestor(pair.second->exec_point());
+      const ExecedProcess* other_proc = pair.second->exec_point();
       if (common_ancestor != proc->exec_point()) {
         proc->exec_point()->disable_shortcutting_bubble_up_to_excl(
-            common_ancestor,
-            "Opened a file for writing which is already opened for writing by a different process");
+            common_ancestor, deduplicated_string(
+                "Opened " + this->to_string()
+                + " for writing which file is already opened for writing by ["
+                + d(other_proc->pid()) + "] \"" +  other_proc->exec_point()->args_to_short_string()
+                + "\"").c_str());
       }
       if (common_ancestor != pair.second->exec_point()) {
         pair.second->exec_point()->disable_shortcutting_bubble_up_to_excl(
-            common_ancestor,
-            "An other process opened a file for writing which is already opened for writing by "
-            "this process");
+            common_ancestor, deduplicated_string(
+                "An other process opened " + this->to_string()
+                + " for writing which file is already opened for writing by ["
+                + d(other_proc->pid()) + "] \"" +  other_proc->exec_point()->args_to_short_string()
+                + "\"").c_str());
       }
     }
   } else {

--- a/src/firebuild/file_usage.cc
+++ b/src/firebuild/file_usage.cc
@@ -52,7 +52,7 @@ const FileUsage* FileUsage::Get(const FileUsage& candidate) {
   }
 }
 
-const FileUsage* FileUsage::merge(const FileUsageUpdate& update) const {
+const FileUsage* FileUsage::merge(const FileUsageUpdate& update, const bool propagated) const {
   FileUsage tmp = *this;
 
   /* Make sure the merged FileUsage is debug-printed upon leaving this method. */
@@ -214,6 +214,11 @@ const FileUsage* FileUsage::merge(const FileUsageUpdate& update) const {
       tmp.tmp_file_ = true;
       changed = true;
     }
+  }
+
+  if (propagated_ != propagated) {
+    tmp.propagated_ = propagated;
+    changed = true;
   }
 
   if (!changed) {

--- a/src/firebuild/file_usage.h
+++ b/src/firebuild/file_usage.h
@@ -52,6 +52,7 @@ class FileUsage {
   bool written() const {return written_;}
   bool mode_changed() const {return mode_changed_;}
   bool tmp_file() const {return tmp_file_;}
+  bool propagated() const {return propagated_;}
   file_generation_t generation() const {return generation_;}
   int unknown_err() {return unknown_err_;}
   void set_unknown_err(int e) {unknown_err_ = e;}
@@ -91,7 +92,7 @@ class FileUsage {
    *
    * @return pointer to the merge result, or nullptr in case of an error
    */
-  const FileUsage* merge(const FileUsageUpdate& update) const;
+  const FileUsage* merge(const FileUsageUpdate& update, const bool propagated) const;
 
   /* Member debugging method. Not to be called directly, call the global d(obj_or_ptr) instead.
    * level is the nesting level of objects calling each other's d(), bigger means less info to print.
@@ -102,9 +103,10 @@ class FileUsage {
   explicit FileUsage(FileType type = DONTKNOW) : initial_state_(type) {}
 
   FileUsage(const FileName* filename, const FileInfo *initial_state, bool written,
-            bool mode_changed, bool tmp_file, int unknown_err):
+            bool mode_changed, bool tmp_file, bool propagated, int unknown_err):
       initial_state_(*initial_state), written_(written), mode_changed_(mode_changed),
-      tmp_file_(tmp_file), generation_(filename->generation()), unknown_err_(unknown_err) {}
+      tmp_file_(tmp_file), propagated_(propagated), generation_(filename->generation()),
+      unknown_err_(unknown_err) {}
 
   /* Things that describe the filesystem when the process started up */
   FileInfo initial_state_;
@@ -124,6 +126,7 @@ class FileUsage {
   /** Created as a temporary file with mktemp() and friends or inferred to be a temporary file
    *  by the supervisor. */
   bool tmp_file_ {false};
+  bool propagated_ {true};
 
   /** Generation of the file the process last seen (either by reading or writing to the file). */
   file_generation_t generation_ {0};

--- a/src/firebuild/report.cc
+++ b/src/firebuild/report.cc
@@ -134,7 +134,9 @@ static void export2js(const ExecedProcess* proc, const unsigned int level,
   /* sort files before printing */
   std::vector<file_file_usage> ordered_file_usages;
   for (auto& pair : proc->file_usages()) {
-    ordered_file_usages.push_back({pair.first, pair.second});
+    if (!pair.second->propagated()) {
+      ordered_file_usages.push_back({pair.first, pair.second});
+    }
   }
   std::sort(ordered_file_usages.begin(), ordered_file_usages.end(), file_file_usage_cmp);
 


### PR DESCRIPTION
Make the report smaller by deduplicating files and process environment.
List files used files at the shortcut process instead of the first ancestor that can be shortcut.