### PR TITLE
interceptor: Fix calling handle_exit()

### DIFF
--- a/src/interceptor/tpl__exit.c
+++ b/src/interceptor/tpl__exit.c
@@ -37,7 +37,7 @@
   insert_end_marker("{{ func }}");
 
   /* Notify the supervisor by calling handle_exit() */
-  handle_exit({{ names_str }});
+  handle_exit();
 
   /* Perform the call */
   {{ call_ic_orig_func }}({{ names_str }});


### PR DESCRIPTION
This fixes the build on latest OS X.

Follow-up for commit e752b247c5fba9297be8bae22d47710916d17dbc.