### PR TITLE
interceptor: Perform seccomp() calls in not intercepted processes

### DIFF
--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -2181,8 +2181,13 @@ generate("mode_t", ["umask", "SYS_umask"], "mode_t mask",
 generate("int", "SYS_seccomp", "unsigned int operation, unsigned int flags, void *args",
          msg_skip_fields=["operation", "flags", "args"],
          msg="seccomp",
-         call_orig_lines=["(void)operation; (void)flags; (void)args;",
-                          "errno = EINVAL; ret =  -1;"])
+         call_orig_lines=["if (i_am_intercepting) {",
+                          "  (void)operation; (void)flags; (void)args;",
+                          "  errno = EINVAL; ret =  -1;"
+                          "} else {",
+                          "  ret = ic_orig_SYS_seccomp(operation, flags, args);",
+                          "}",
+                          ])
 
 # FIXME {get,set,p}rlimit
 


### PR DESCRIPTION
The interceptor minimizes its impact on the intercepted process' behavior. Seccomp() call are blocked because they can interfere with the interceptor's communication with the firebuild supervisor, but when interception is disabled they can be executed.

Follow-up for commit 198aeb17ef5a1b216ec7e5af38f882d0ff295e5b.