### PR TITLE
config: Ignore /sys/devices

### DIFF
--- a/etc/firebuild.conf
+++ b/etc/firebuild.conf
@@ -119,6 +119,7 @@ ignore_locations = [
   "/proc/meminfo",
   "/proc/self",
   "/proc/stat",
+  "/sys/devices",
   "/sys/fs/cgroup"
 ];
 


### PR DESCRIPTION
Java recently started checking "/sys/devices/system/cpu/cpu0/microcode/version" which is unlikely to influence build outputs.