### PR TITLE
supervisor: Support GLibc 2.38 passing "--" right after "sh -c"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,6 +29,7 @@ Package: firebuild
 Architecture: any
 Depends: ${shlibs:Depends},
          ${misc:Depends},
+         ${glibc:Depends},
          libfirebuild0 (= ${binary:Version})
 Pre-Depends: debconf | debconf-2.0
 Suggests: graphviz,
@@ -51,7 +52,9 @@ Description: Automatic build accelerator cache
 Package: libfirebuild0
 Architecture: any
 Multi-Arch: same
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends},
+         ${misc:Depends},
+         ${glibc:Depends}
 Pre-Depends: debconf | debconf-2.0
 Description: Automatic build accelerator cache - shared library
  It works by caching the outputs of executed commands and replaying the

--- a/debian/rules
+++ b/debian/rules
@@ -13,6 +13,8 @@ export DEB_CXXFLAGS_MAINT_STRIP = -ffat-lto-objects
 export DEB_LDLAGS_MAINT_STRIP = -ffat-lto-objects
 endif
 
+VER_GLIBC := $(shell dpkg -s libc6 | grep ^Version: | cut -f2 -d' ' | cut -f1 -d '-')
+
 %:
 	dh $@
 
@@ -35,6 +37,9 @@ override_dh_auto_test:
 ifeq ($(filter nocheck,$(DEB_BUILD_OPTIONS)),)
 	make -C obj-* check
 endif
+
+override_dh_gencontrol:
+	dh_gencontrol -- '-Vglibc:Depends=libc6 (>= '$(VER_GLIBC)')'
 
 override_dh_installchangelogs:
 	dh_installchangelogs -k ChangeLog

--- a/src/firebuild/execed_process_cacher.cc
+++ b/src/firebuild/execed_process_cacher.cc
@@ -648,8 +648,12 @@ void ExecedProcessCacher::store(ExecedProcess *proc) {
 
     // Parent may just be sh -c <this command>, detect that
     parent_may_be_just_sh_c_this = (parent_exec_point->can_shortcut()
-                                    && parent_exec_point->args().size() == 3
-                                    && parent_exec_point->args()[1] == "-c"
+                                    && ((parent_exec_point->args().size() == 4
+                                         && parent_exec_point->args()[1] == "-c"
+                                         && parent_exec_point->args()[2] == "--")
+                                        || (parent_exec_point->args().size() == 3
+                                            && parent_exec_point->args()[1] == "-c")
+                                        )
                                     && shells->contains(parent_exec_point->args()[0]));
   }
 

--- a/src/firebuild/execed_process_env.cc
+++ b/src/firebuild/execed_process_env.cc
@@ -30,6 +30,7 @@ ExecedProcessEnv::ExecedProcessEnv(std::vector<std::shared_ptr<FileFD>>* fds,
 void ExecedProcessEnv::set_sh_c_command(const std::string &cmd) {
   argv_.push_back("sh");
   argv_.push_back("-c");
+  argv_.push_back("--");
   argv_.push_back(cmd);
 }
 

--- a/src/firebuild/message_processor.cc
+++ b/src/firebuild/message_processor.cc
@@ -617,7 +617,7 @@ static void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf, uint16_t ack_num,
     case FBBCOMM_TAG_system: {
       auto ic_msg = reinterpret_cast<const FBBCOMM_Serialized_system *>(fbbcomm_buf);
       assert_null(proc->system_child());
-      /* system(cmd) launches a child of argv = ["sh", "-c", cmd] */
+      /* system(cmd) launches a child of argv = ["sh", "-c", "--", cmd], with "--" being optional */
       auto expected_child = new ExecedProcessEnv(proc->pass_on_fds(false), LAUNCH_TYPE_SYSTEM);
       if (ic_msg->has_cmd()) {
         expected_child->set_sh_c_command(ic_msg->get_cmd());
@@ -658,7 +658,7 @@ static void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf, uint16_t ack_num,
 
       int type_flags = ic_msg->get_type_flags();
       auto fds = proc->pass_on_fds(false);
-      /* popen(cmd) launches a child of argv = ["sh", "-c", cmd] */
+      /* popen(cmd) launches a child of argv = ["sh", "-c", "--", cmd], with "--" being optional */
       auto expected_child = new ExecedProcessEnv(fds, LAUNCH_TYPE_POPEN);
       // FIXME what if !has_cmd() ?
       expected_child->set_sh_c_command(ic_msg->get_cmd());
@@ -693,7 +693,7 @@ static void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf, uint16_t ack_num,
       auto ic_msg = reinterpret_cast<const FBBCOMM_Serialized_popen_failed *>(fbbcomm_buf);
       // FIXME what if !has_cmd() ?
       delete(proc->pop_expected_child_fds(
-          std::vector<std::string>({"sh", "-c", ic_msg->get_cmd()}),
+          std::vector<std::string>({"sh", "-c", "--", ic_msg->get_cmd()}),
           nullptr, nullptr, true));
       break;
     }


### PR DESCRIPTION
with system() and popen() calls. Still handle "sh" "-c" "cmd" form when compiling with earlier GLibc and other libc versions.