### PR TITLE
tests: Fix test_symbols script on OS X

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,7 +16,7 @@ function(add_test_binary TEST_BINARY)
   add_dependencies(check-bins "${TEST_BINARY}")
 endfunction()
 
-foreach(TESTFILE empty-config.conf integration.bats test_parallel_make.Makefile test_symbols)
+foreach(TESTFILE empty-config.conf integration.bats print_tbd_lib_arch_exports test_parallel_make.Makefile test_symbols)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/${TESTFILE}" "${CMAKE_CURRENT_BINARY_DIR}/${TESTFILE}" COPYONLY)
 endforeach()
 
@@ -78,4 +78,8 @@ add_dependencies(check-deps firebuild-bin)
 add_dependencies(check check-deps check-bins)
 add_dependencies(valgrind-check check-deps check-bins)
 
-add_test(test-symbols ./test_symbols ${CMAKE_BINARY_DIR})
+if(APPLE)
+  add_test(test-symbols env CMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT} ./test_symbols ${CMAKE_BINARY_DIR})
+else()
+  add_test(test-symbols ./test_symbols ${CMAKE_BINARY_DIR})
+endif()

--- a/test/print_tbd_lib_arch_exports
+++ b/test/print_tbd_lib_arch_exports
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2023 Firebuild Inc.
+# All rights reserved.
+# Free for personal use and commercial trial.
+# Non-trial commercial use requires licenses available from https://firebuild.com.
+# Modification and redistribution are permitted, but commercial use of
+# derivative works is subject to the same requirements of this license
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Parse mac tbd and print exported symbols for a library and an architecture
+
+import re
+import sys
+
+list_pattern=r'[^:^[^ ^,^\]^\']+'
+
+
+def parse_tapi_tbd(text):
+    entries = re.split(r'--- !tapi-tbd', text)[1:]
+    result = {}
+
+    for entry in entries:
+        lines = entry.strip().split('\n')
+        entry_data = {'tbd-version': None,
+                      'targets': [],
+                      'install-name': None,
+                      'current-version': None,
+                      'reexported-libraries': {},
+                      'parent-umbrella': {},
+                      'exports': {}}
+        key = None  # remember top level key
+        subkey = None
+        targets = None
+        for line in lines:
+            if line.startswith("targets:"):
+                key, value = map(str.strip, line.split(':', 1))
+                entry_data[key].extend(re.findall(list_pattern, value))
+                subkey = None
+            elif line.startswith("install-name:") \
+                 or line.startswith("current-version:") \
+                 or line.startswith("tbd-version:"):
+                key, value = map(str.strip, line.split(':', 1))
+                entry_data[key] = re.sub(r'\'', "", value)
+                subkey = None
+            elif line == "reexported-libraries:" \
+                 or line == "parent-umbrella:" \
+                 or line == "reexports:" \
+                 or line == "exports:":
+                key, _value = map(str.strip, line.split(':', 1))
+                entry_data[key] = {}
+                for target in entry_data['targets']:
+                    entry_data[key][target] = []
+            elif line.startswith("    umbrella:"):
+                subkey, value = map(str.strip, line.split(':', 1))
+                entry_data[key][subkey] = value
+            elif line.startswith("  - targets:"):
+                subkey, value = map(str.strip, line.split(':', 1))
+                subkey = subkey.replace("-", " ").strip()
+                targets = re.findall(list_pattern, value)
+            elif line.startswith("    libraries:") \
+                 or line.startswith("    symbols:"):
+                subkey, value = map(str.strip, line.split(':', 1))
+                subkey = subkey.replace("-", " ").strip()
+                for target in targets:
+                    entry_data[key][target].extend(re.findall(list_pattern, value))
+            else:
+                if subkey is None:
+                    entry_data[key].extend(re.findall(list_pattern, line))
+                elif subkey == 'targets':
+                    targets.extend(re.findall(list_pattern, line))
+                elif subkey in ('symbols', 'libraries'):
+                    for target in targets:
+                         entry_data[key][target].extend(re.findall(list_pattern, line))
+        result[entry_data['install-name']] = entry_data
+
+    return result
+
+if len(sys.argv) != 4:
+    print("Usage:")
+    print(" {} <.tbd> <library> <architecture>".format(sys.argv[0]))
+    sys.exit(1)
+
+with open(sys.argv[1], "r") as f:
+    tbd = parse_tapi_tbd(f.read())
+    for symbol in tbd[sys.argv[2]]['exports'][sys.argv[3]]:
+        print(symbol)
+

--- a/test/test_symbols
+++ b/test/test_symbols
@@ -28,8 +28,23 @@ binary_dir="$1"
 
 status=0
 
+platform=$(uname)
+case "$platform" in
+    "Linux")
+        libfirebuild="$binary_dir/src/interceptor/libfirebuild.so"
+        ;;
+    "Darwin")
+        libfirebuild="$binary_dir/src/interceptor/libfirebuild.dylib"
+        ;;
+esac
+
 # Additional allowed public symbols that are not auto-generated into gen_list.txt.
 additional_allowed_symbols=""
+
+known_missing_Darwin_64bit="_fstat64
+_fstatat64
+_lstat64
+_stat64"
 
 function check_function_class () {
     local fix=$1
@@ -47,7 +62,7 @@ function check_function_class () {
 
     # Get the list of libc symbols that we don't override, but override the
     # counterpart with the prefix/postfix
-    local missing=$(for chk in $(< libc-${class}-symbols.txt); do
+    local missing=`for chk in $(< libc-${class}-symbols.txt); do
                         case $kind in
                             "prefix")
                                 base="${chk#__}"
@@ -63,13 +78,15 @@ function check_function_class () {
                                 fi
                                 ;;
                         esac
-                    done)
+                    done`
 
     # Report the non-overridden symbols
-    if [ -z "$missing" ]; then
+    known_missing_varname="known_missing_${platform}_${class}"
+    if [ -z "$missing" -o "(" "${!known_missing_varname}" = "$missing" ")" ]; then
         echo "All expected ${class} methods overridden"
     else
-        echo "${class@u} methods not overridden:"
+        echo "${!known_missing_varname}"
+        echo "${class} methods not overridden:"
         echo "$missing" | sed 's/^\(.*\)$/  \1/'
         status=1
     fi
@@ -78,7 +95,8 @@ function check_function_class () {
 # Extract and sort the public symbols of our library,
 # filtering out the ones added by gcov (__gcov* and mangle_path)
 # and ones appearing with old toolchains(__bss_start, _edata, etc.)
-nm -D "$binary_dir/src/interceptor/libfirebuild.so" | \
+nm --extern-only "$libfirebuild" | \
+  sed 's/_interposing//' | \
   grep -v ' [Uvw] ' | \
   cut -d' ' -f3- | \
   grep -v '^__gcov_' | \
@@ -136,13 +154,27 @@ shm_open
 shm_unlink
 "
 # TODO(rbalint) provide properly versioned symbols in libfirebuild
-libs=$(LD_PRELOAD=libpthread.so.0 ldd "$binary_dir/src/interceptor/libfirebuild.so" | grep -E 'lib(c|dl|pthread).so' | cut -d' ' -f3)
-(nm -D $libs | \
-     grep ' [TWi] ' | \
-     cut -d' ' -f3- ; \
-     echo "$known_extra") | \
-  sed 's/\(.*\)@@\(.*\)/\1@@\2\n\1/' | \
-  LC_ALL=C sort > libc-symbols.txt
+
+case "$platform" in
+    "Linux")
+        libs=$(LD_PRELOAD=libpthread.so.0 ldd $libfirebuild | grep -E 'lib(c|dl|pthread).so' | cut -d' ' -f3)
+        (nm -D $libs | \
+             grep ' [TWi] ' | \
+             cut -d' ' -f3- ; \
+         echo "$known_extra") | \
+            sed 's/\(.*\)@@\(.*\)/\1@@\2\n\1/' | \
+            LC_ALL=C sort > libc-symbols.txt
+        ;;
+    "Darwin")
+        lib=$(otool -L $libfirebuild | awk '/\/usr\/lib/ {print $1}')
+        rm -f libc-symbols.txt
+        (for arch in arm64 arm64e x86_64; do
+             for exported_lib in "libdyld" "libsystem_c" "libsystem_info" "libsystem_kernel" "libsystem_pthread" "libsystem_blocks"; do
+                 "$binary_dir/test/print_tbd_lib_arch_exports" "${CMAKE_OSX_SYSROOT}/${lib%.dylib}.tbd" "/usr/lib/system/${exported_lib}.dylib" ${arch}-macos
+             done
+        done) | LC_ALL=C sort | uniq > libc-symbols.txt
+        ;;
+esac
 
 # Get the list of extra ones
 extra=$(LC_ALL=C comm -23 public-symbols.txt libc-symbols.txt)


### PR DESCRIPTION
The test still fails, but it shows the missing symbols properly.