### PR TITLE
supervisor: Remove fd_ member from FileFD

### DIFF
--- a/src/firebuild/execed_process.cc
+++ b/src/firebuild/execed_process.cc
@@ -142,14 +142,16 @@ void ExecedProcess::initialize() {
    * The outer list (according to the lowest fd) and the inner lists are all sorted. */
   std::vector<inherited_file_t> inherited_files;
   /* This iterates over the fds in increasing order. */
-  for (auto file_fd : *fds()) {
+  int fds_size = fds()->size();
+  for (int fd = 0; fd < fds_size; fd++) {
+    const FileFD* file_fd = get_fd(fd);
     if (!file_fd) {
       continue;
     }
     bool found = false;
     for (inherited_file_t& inherited_file : inherited_files) {
       if (get_fd(inherited_file.fds[0])->fdcmp(*file_fd) == 0) {
-        inherited_file.fds.push_back(file_fd->fd());
+        inherited_file.fds.push_back(fd);
         found = true;
         break;
       }
@@ -158,7 +160,7 @@ void ExecedProcess::initialize() {
       inherited_file_t inherited_file;
       inherited_file.type = file_fd->type();
       assert(inherited_file.type != FD_UNINITIALIZED);
-      inherited_file.fds.push_back(file_fd->fd());
+      inherited_file.fds.push_back(fd);
       inherited_file.filename = file_fd->filename();
       inherited_file.flags = file_fd->flags();
       inherited_files.push_back(inherited_file);

--- a/src/firebuild/file_fd.cc
+++ b/src/firebuild/file_fd.cc
@@ -70,7 +70,7 @@ std::string d(const FileOFD *fofd, const int level) {
   }
 }
 std::string d(const FileFD& ffd, const int level) {
-  std::string ret = "{FileFD fd=" + d(ffd.fd()) + " " + d(ffd.ofd(), level);
+  std::string ret = "{FileFD ofd=" + d(ffd.ofd(), level);
   if (ffd.pipe()) {
     ret += " " + d(ffd.pipe().get(), level + 1);
     ret += " close_on_popen=" + d(ffd.close_on_popen());

--- a/src/firebuild/process.h
+++ b/src/firebuild/process.h
@@ -191,7 +191,7 @@ class Process {
     for (int i = fds_->size() - 1; i >= 0; i--) {
       FileFD* file_fd = get_fd(i);
       if (file_fd) {
-        handle_close(file_fd);
+        handle_close(file_fd, i);
       }
     }
   }
@@ -300,8 +300,9 @@ class Process {
   /**
    * Handle file closure in the monitored process
    * @param file_fd FileFD* to close
+   * @param fd file descriptor to close
    */
-  void handle_close(FileFD * file_fd);
+  void handle_close(FileFD * file_fd, const int fd);
 
   /**
    * Handle file closure in the monitored process when we don't know

--- a/src/firebuild/process_tree.cc
+++ b/src/firebuild/process_tree.cc
@@ -85,7 +85,7 @@ void ProcessTree::insert_root(pid_t root_pid, int stdin_fd, int stdout_fd, int s
   root_->set_state(firebuild::FB_PROC_TERMINATED);
   // TODO(rbalint) support other inherited fds
   /* Create the FileFD representing stdin of the top process. Pipe will be NULL, that's fine. */
-  root_->add_filefd(stdin_fd, std::make_shared<FileFD>(stdin_fd, O_RDONLY, nullptr, nullptr));
+  root_->add_filefd(stdin_fd, std::make_shared<FileFD>(O_RDONLY, nullptr, nullptr));
 
   /* Create the Pipes and FileFDs representing stdout and stderr of the top process. */
   // FIXME Make this more generic, for all the received pipes / terminal outputs.
@@ -98,7 +98,7 @@ void ProcessTree::insert_root(pid_t root_pid, int stdin_fd, int stdout_fd, int s
     if (fd == stderr_fd && stdout_stderr_match) {
       /* stdout and stderr point to the same location (changing one's flags did change the
        * other's). Reuse the Pipe object that we created in the loop's first iteration. */
-      root_->add_filefd(fd, std::make_shared<FileFD>(fd, (*root_->fds())[stdout_fd], false));
+      root_->add_filefd(fd, std::make_shared<FileFD>((*root_->fds())[stdout_fd], false));
     } else {
       /* Create a new Pipe for this file descriptor.
        * The fd keeps blocking/non-blocking behaviour, it seems to be ok with epoll.
@@ -116,7 +116,7 @@ void ProcessTree::insert_root(pid_t root_pid, int stdin_fd, int stdout_fd, int s
       FB_DEBUG(FB_DEBUG_PIPE, "created pipe with fd0: " + d(fd) + ", dup()-ed as: " + d(fd_dup));
       /* Top level inherited fds are special, they should not be closed. */
       inherited_fd_pipes_.insert(pipe);
-      root_->add_filefd(fd, std::make_shared<FileFD>(fd, O_WRONLY, pipe, nullptr));
+      root_->add_filefd(fd, std::make_shared<FileFD>(O_WRONLY, pipe, nullptr));
     }
   }
   insert_process(root_);


### PR DESCRIPTION
The fd_ member was redundant and could go out of sync with the actual fd the FileFD is assigned to.