### PR TITLE
Fix intercepting __mac_syscall()

### DIFF
--- a/src/common/fbbcomm.def
+++ b/src/common/fbbcomm.def
@@ -901,5 +901,13 @@
       (OPTIONAL, STRING, "pathname"),
       (OPTIONAL, "int", "error_no"),
     ]),
+
+    ("mac_syscall", [
+      (REQUIRED, STRING, "policy"),
+      (REQUIRED, "int", "call"),
+      (OPTIONAL, "int", "ret"),
+      # error no., when ret = -1
+      (OPTIONAL, "int", "error_no"),
+    ]),
   ]
 }

--- a/src/firebuild/message_processor.cc
+++ b/src/firebuild/message_processor.cc
@@ -1206,6 +1206,10 @@ static void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf, uint16_t ack_num,
       /* Ignore seccomp(). The interposer always returns EINVAL error to keep interception
        * working. This breaks sandboxing, but builds can run arbitrary commands anyway. */
       break;
+    case FBBCOMM_TAG_mac_syscall:
+      /* Ignore __mac_syscall(). Having the tag defined allows easier debugging with -d comm. */
+      // TODO(rbalint) check if any __mac_syscall() invocation could impact builds
+      break;
     case FBBCOMM_TAG_fb_debug:
     case FBBCOMM_TAG_fb_error:
     case FBBCOMM_TAG_fchownat:

--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -2407,11 +2407,17 @@ generate("long", "syscall", "long number, ...",
          tpl="syscall",
          send_ret_on_success=True,
          ack_condition="true")
-generate("int", ["syscall", "__syscall", "__mac_syscall"], "int number, ...",
+generate("int", ["syscall", "__syscall"], "int number, ...",
          platforms=["darwin"],
          tpl="syscall",
          send_ret_on_success=True,
          ack_condition="true")
+
+generate("int", ["__mac_syscall", "SYS___mac_syscall"], "char* policy, int call, user_addr_t arg",
+         platforms=["darwin"],
+         msg="mac_syscall",
+         msg_skip_fields=["arg"],
+         send_ret_on_success=True)
 
 # FIXME This is temporary only, until intercepting confstr is implemented:
 #generate("size_t", "confstr", "int name, char *buf, size_t len")


### PR DESCRIPTION
Don't disable shortcutting, just intercept and report to the supervisor.