### PR TITLE
Fix finding libfirebuild library on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,11 @@ Install the build dependencies:
 
 Build:
 
-    cmake . && make
+    cmake . && make check
+
+Install:
+
+    sudo make install
 
 ### On Mac
 
@@ -124,4 +128,8 @@ Build:
     export XML_CATALOG_FILES=/usr/local/etc/xml/catalog
     export PATH=$(ls -d /opt/homebrew/Cellar/jinja2-cli/*/libexec/bin):$PATH
     cmake -DCMAKE_CXX_FLAGS="-I/opt/homebrew/include -I/usr/local/include" -DCMAKE_EXE_LINKER_FLAGS="-L/opt/homebrew/lib" .
-    make
+    make check
+
+Install:
+
+    sudo --preserve-env=XML_CATALOG_FILES make install

--- a/etc/firebuild.conf
+++ b/etc/firebuild.conf
@@ -5,6 +5,8 @@ version = 1.0;
 // enviromnent variables passed to the build command
 env_vars = {
   // the following environment variables are passed to the build command unchanged
+  // Note that if DYLD_LIBRARY_PATH is not set on MacOS, it is set by firebuild
+  // to the path where libfirebuild is installed.
   pass_through = [ "HOME", "PATH", "SHELL", "PWD", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"];
 
   // These env vars are skipped when computing an intercepted command's fingerprint.

--- a/src/firebuild/CMakeLists.txt
+++ b/src/firebuild/CMakeLists.txt
@@ -5,6 +5,7 @@ set_source_files_properties(debug.cc execed_process.cc file_name.cc obj_cache.cc
 # FBB structures and placing them aligned in buffers ensure that members will be aligned properly, too
 set_source_files_properties(execed_process_cacher.cc PROPERTIES COMPILE_FLAGS "-Wno-cast-align -Wno-strict-overflow")
 set_source_files_properties(message_processor.cc PROPERTIES COMPILE_FLAGS "-DFIREBUILD_VERSION='\"${FIREBUILD_VERSION}\"' -Wno-cast-align")
+set_source_files_properties(config.cc PROPERTIES COMPILE_FLAGS "-DFB_INTERCEPTOR_FULL_LIBDIR=\\\"${CMAKE_INSTALL_FULL_LIBDIR}\\\"")
 
 set_source_files_properties(firebuild.cc PROPERTIES COMPILE_FLAGS "-DFIREBUILD_VERSION='\"${FIREBUILD_VERSION}\"'")
 

--- a/src/firebuild/config.cc
+++ b/src/firebuild/config.cc
@@ -490,6 +490,13 @@ char** get_sanitized_env(libconfig::Config *cfg, const char *fb_conn_string,
   env["DYLD_FORCE_FLAT_NAMESPACE"] = "0";
   FB_DEBUG(firebuild::FB_DEBUG_PROC, " DYLD_FORCE_FLAT_NAMESPACE=" +
            env["DYLD_FORCE_FLAT_NAMESPACE"]);
+
+  const char *ld_library_path_value = getenv(LD_LIBRARY_PATH);
+  if (!ld_library_path_value) {
+    env[LD_LIBRARY_PATH] = FB_INTERCEPTOR_FULL_LIBDIR;
+  }
+  FB_DEBUG(firebuild::FB_DEBUG_PROC, " " LD_LIBRARY_PATH "=" + env[LD_LIBRARY_PATH]);
+
 #endif
   env["FB_SOCKET"] = fb_conn_string;
   FB_DEBUG(FB_DEBUG_PROC, " FB_SOCKET=" + env["FB_SOCKET"]);


### PR DESCRIPTION
Also add installation instructions now that installed `firebuild` works on macOS, too.