### PR TITLE
Intercept scandir() variants

### DIFF
--- a/src/common/fbbcomm.def
+++ b/src/common/fbbcomm.def
@@ -256,6 +256,15 @@
       (REQUIRED, "bool", "pre_open_sent"),
     ]),
 
+    ("scandirat", [
+      # dir file descriptor for scandirat()
+      (OPTIONAL, "int", "dirfd"),
+      # file path
+      (OPTIONAL, STRING, "dirp"),
+      # error no., when ret = -1
+      (OPTIONAL, "int", "error_no"),
+    ]),
+
     ("chdir", [
       # directory path
       (OPTIONAL, STRING, "pathname"),

--- a/src/firebuild/message_processor.cc
+++ b/src/firebuild/message_processor.cc
@@ -1013,6 +1013,10 @@ static void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf, uint16_t ack_num,
       PFBBA_HANDLE(proc, close_range, fbbcomm_buf);
       break;
     }
+    case FBBCOMM_TAG_scandirat: {
+      PFBBA_HANDLE(proc, scandirat, fbbcomm_buf);
+      break;
+    }
     case FBBCOMM_TAG_truncate: {
       PFBBA_HANDLE(proc, truncate, fbbcomm_buf);
       break;

--- a/src/firebuild/process.cc
+++ b/src/firebuild/process.cc
@@ -428,6 +428,50 @@ int Process::handle_dlopen(const char * const absolute_filename,
   return 0;
 }
 
+int Process::handle_scandirat(const int dirfd, const char * const ar_name, const size_t ar_len,
+                              const int error) {
+  TRACKX(FB_DEBUG_PROC, 1, 1, Process, this,
+         "dirfd=%d, ar_name=%s, error=%d", dirfd, D(ar_name), error);
+
+  if (error) {
+    if (error == ENOENT) {
+      /* scandirat() failed, because the directory doesn't exist. */
+      const FileName* name = get_absolute(dirfd, ar_name, ar_len);
+      if (!name) {
+        exec_point()->disable_shortcutting_bubble_up(
+            "Invalid dirfd or filename passed to scandirat()");
+        return -1;
+      }
+      FileUsageUpdate update(name, NOTEXIST);
+      if (!exec_point()->register_file_usage_update(name, update)) {
+        exec_point()->disable_shortcutting_bubble_up("Could not register scandirat() on", *name);
+        return -1;
+      }
+      return 0;
+    } else {
+      /* scandirat() failed, but we don't know why. */
+      exec_point()->disable_shortcutting_bubble_up("scandirat() failed");
+      return -1;
+    }
+  }
+
+  const FileName* name = get_absolute(dirfd, ar_name, ar_len);
+  if (!name) {
+    exec_point()->disable_shortcutting_bubble_up(
+        "Invalid dirfd or filename passed to scandirat()");
+    return -1;
+  }
+
+  FileUsageUpdate update =
+       FileUsageUpdate::get_from_open_params(name, O_RDONLY | O_DIRECTORY, 0, error, false);
+  if (!exec_point()->register_file_usage_update(name, update)) {
+    exec_point()->disable_shortcutting_bubble_up("Could not register scandirat() on", *name);
+    return -1;
+  }
+
+  return 0;
+}
+
 int Process::handle_truncate(const char * const ar_name, const size_t ar_len,
                              const off_t length, const int error) {
   TRACKX(FB_DEBUG_PROC, 1, 1, Process, this,

--- a/src/firebuild/process.h
+++ b/src/firebuild/process.h
@@ -327,6 +327,12 @@ class Process {
                          const int flags, const int error = 0);
 
   /**
+   * Handle scandirat() in the monitored process.
+   */
+  int handle_scandirat(const int dirfd, const char * const ar_name, const size_t ar_name_len,
+                       const int error);
+
+  /**
    * Handle truncate() in the monitored process..
    */
   int handle_truncate(const char * const ar_name, const size_t ar_len,

--- a/src/firebuild/process_fbb_adaptor.h
+++ b/src/firebuild/process_fbb_adaptor.h
@@ -81,6 +81,15 @@ class ProcessFBBAdaptor {
     const int error = msg->get_error_no_with_fallback(0);
     return proc->handle_close_range(msg->get_first(), msg->get_last(), msg->get_flags(), error);
   }
+
+  static int handle(Process *proc, const FBBCOMM_Serialized_scandirat *msg) {
+    const int error = msg->get_error_no_with_fallback(0);
+    return proc->handle_scandirat(msg->get_dirfd_with_fallback(AT_FDCWD),
+                                  msg->has_dirp() ? msg->get_dirp() : nullptr,
+                                  msg->has_dirp() ? msg->get_dirp_len() : 0,
+                                  error);
+  }
+
   static int handle(Process *proc, const FBBCOMM_Serialized_truncate *msg) {
     const int error = msg->get_error_no_with_fallback(0);
     return proc->handle_truncate(msg->get_pathname(), msg->get_pathname_len(),

--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -574,7 +574,22 @@ generate("int", "closedir", "DIR *dirp",
          msg="close",
          msg_skip_fields=["dirp"],
          msg_add_fields=["fbbcomm_builder_close_set_fd(&ic_msg, fd);"])
-# FIXME implement scandir(at)(64)
+
+generate("int", "scandir", "const char *dirp, struct dirent ***namelist, int (*filter)(const struct dirent *), int (*compar)(const struct dirent **, const struct dirent **)",
+         msg="scandirat",
+         msg_skip_fields=["dirp", "namelist", "filter", "compar"],
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(scandirat, dirp);"])
+generate("int", "scandir64", "const char *dirp, struct dirent64 ***namelist, int (*filter)(const struct dirent64 *), int (*compar)(const struct dirent64 **, const struct dirent64 **)",
+         msg="scandirat",
+         msg_skip_fields=["dirp", "namelist", "filter", "compar"],
+         msg_add_fields=["BUILDER_SET_ABSOLUTE_CANONICAL(scandirat, dirp);"])
+generate("int", "scandirat", "int dirfd, const char *dirp, struct dirent ***namelist, int (*filter)(const struct dirent *), int (*compar)(const struct dirent **, const struct dirent **)",
+         platforms=['linux'],
+         msg_skip_fields=["dirp", "namelist", "filter", "compar"],
+         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(scandirat, dirfd, dirp);"])
+generate("int", "scandirat64", "int dirfd, const char *dirp, struct dirent64 ***namelist, int (*filter)(const struct dirent64 *), int (*compar)(const struct dirent64 **, const struct dirent64 **)",
+         msg_skip_fields=["dirp", "namelist", "filter", "compar"],
+         msg_add_fields=["BUILDER_MAYBE_SET_ABSOLUTE_CANONICAL(scandirat, dirfd, dirp);"])
 
 generate("int", ["mkdir", "SYS_mkdir"], "const char *pathname, mode_t mode",
          msg_skip_fields=["pathname"],

--- a/test/test_file_ops.c
+++ b/test/test_file_ops.c
@@ -149,6 +149,13 @@ int main() {
   closedir(d);
 #endif
 
+  struct dirent **namelist;
+  if (scandir("./", &namelist, NULL, NULL) == -1) {
+    perror("scandir" LOC);
+    exit(1);
+  }
+  free(namelist);
+
   if (mkdir("test_directory", 0700) == -1) {
     perror("mkdir" LOC);
     exit(1);


### PR DESCRIPTION
This fixes shortcutting clang on macOS