### PR TITLE
interceptor: Allow interception inside dlopen() and dlmopen()

### DIFF
--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -1712,16 +1712,12 @@ generate("int", ["futimens", "__futimens64"], "int fd, const struct timespec tim
 # in send_msg_condition we have to skip the default exception on EINTR and EFAULT.
 generate("void *", "dlopen", "const char *filename, int flag",
          tpl="dlopen",
-         before_lines=["FB_THREAD_LOCAL(intercept_on) = NULL;"],
-         after_lines=["FB_THREAD_LOCAL(intercept_on) = \"dlopen\";"],
          send_msg_condition="true",
          msg_skip_fields=["error_no"])
 generate("void *", "dlmopen", "Lmid_t lmid, const char *filename, int flag",
          platforms=['linux'],
          tpl="dlopen",
          msg="dlopen",
-         before_lines=["FB_THREAD_LOCAL(intercept_on) = NULL;"],
-         after_lines=["FB_THREAD_LOCAL(intercept_on) = \"dlmopen\";"],
          send_msg_condition="true",
          msg_skip_fields=["lmid", "error_no"])
 

--- a/src/interceptor/tpl_dlopen.c
+++ b/src/interceptor/tpl_dlopen.c
@@ -30,11 +30,16 @@
 ### block before
   /* TODO(rbalint) Save all loaded images before the dlopen() to collect also loaded shared
    * library dependencies. */
-  FB_THREAD_LOCAL(interception_recursion_depth)++;
+  /* Release lock to allow intercepting shared library constructors. */
+  if (i_locked) {
+    release_global_lock();
+  }
 ### endblock before
 
 ### block after
-  FB_THREAD_LOCAL(interception_recursion_depth)--;
+    if (i_am_intercepting) {
+      grab_global_lock(&i_locked, "{{ func }}");
+    }
 
   const char *absolute_filename = NULL;
   if (success) {


### PR DESCRIPTION
This fixes `firebuild xcodebuild -h` hanging.