### PR TITLE
supervisor: Use memcmp() instead of strcmp() where the string lengths are known

### DIFF
--- a/src/firebuild/execed_process_cacher.cc
+++ b/src/firebuild/execed_process_cacher.cc
@@ -980,7 +980,8 @@ void ExecedProcessCacher::store(ExecedProcess *proc) {
    * locations. */
   struct {
     bool operator()(const FBBSTORE_Builder_file& a, const FBBSTORE_Builder_file& b) const {
-      return strcmp(a.get_path(), b.get_path()) < 0;
+      return memcmp(a.get_path(), b.get_path(),
+                    std::min(a.get_path_len(), b.get_path_len()) + 1) < 0;
     }
   } file_less;
   /* Sort non-system and system paths separately to not regress in shortcutting performance. */
@@ -991,7 +992,7 @@ void ExecedProcessCacher::store(ExecedProcess *proc) {
 
   struct {
     bool operator()(const cstring_view& a, const cstring_view& b) const {
-      return strcmp(a.c_str, b.c_str) < 0;
+      return memcmp(a.c_str, b.c_str, std::min(a.length, b.length) + 1) < 0;
     }
   } cstring_view_less;
   /* Sort non-system and system paths separately to not regress in shortcutting performance. */

--- a/src/firebuild/file_name.h
+++ b/src/firebuild/file_name.h
@@ -22,6 +22,7 @@
 #include <tsl/hopscotch_map.h>
 #include <xxhash.h>
 
+#include <algorithm>
 #include <cstring>
 #include <string>
 #include <unordered_set>
@@ -166,7 +167,7 @@ struct FileNameHasher {
 /** Helper struct for std::sort */
 struct FileNameLess {
   bool operator()(const FileName* f1, const FileName* f2) const {
-    return strcmp(f1->c_str(), f2->c_str()) < 0;
+    return memcmp(f1->c_str(), f2->c_str(), std::min(f1->length(), f2->length()) + 1) < 0;
   }
 };
 

--- a/src/firebuild/file_usage.cc
+++ b/src/firebuild/file_usage.cc
@@ -20,6 +20,7 @@
 
 #include <sys/stat.h>
 
+#include <algorithm>
 #include <string>
 #include <unordered_set>
 
@@ -229,7 +230,8 @@ const FileUsage* FileUsage::merge(const FileUsageUpdate& update, const bool prop
 }
 
 bool file_file_usage_cmp(const file_file_usage& lhs, const file_file_usage& rhs) {
-  return strcmp(lhs.file->c_str(), rhs.file->c_str()) < 0;
+  return memcmp(lhs.file->c_str(), rhs.file->c_str(),
+                std::min(lhs.file->length(), rhs.file->length()) + 1) < 0;
 }
 
 std::string FileUsage::d_internal(const int level) const {


### PR DESCRIPTION
This makes the operations slightly faster.