### PR TITLE
supervisor: Move member initializations to constants to member definitions.

### DIFF
--- a/src/firebuild/execed_process.cc
+++ b/src/firebuild/execed_process.cc
@@ -53,7 +53,6 @@ ExecedProcess::ExecedProcess(const int pid, const int ppid,
                              std::vector<std::shared_ptr<FileFD>>* fds)
     : Process(pid, ppid, parent ? parent->exec_count() + 1 : 1, initial_wd, umask, parent,
               fds, debug_suppressed),
-      can_shortcut_(true), was_shortcut_(false),
       maybe_shortcutable_ancestor_(
           (parent && parent->exec_point()) ? parent->exec_point()->closest_shortcut_point()
           : nullptr),

--- a/src/firebuild/execed_process.h
+++ b/src/firebuild/execed_process.h
@@ -257,8 +257,8 @@ class ExecedProcess : public Process {
   virtual std::string d_internal(const int level = 0) const;
 
  private:
-  bool can_shortcut_:1;
-  bool was_shortcut_:1;
+  bool can_shortcut_:1 = true;
+  bool was_shortcut_:1 = false;
   int16_t jobserver_fd_r_ = -1;
   int16_t jobserver_fd_w_ = -1;
   /** If points to this (self), the process can be shortcut.

--- a/src/firebuild/file_name.h
+++ b/src/firebuild/file_name.h
@@ -110,7 +110,7 @@ class FileName {
  private:
   FileName(const char * const name, size_t length, bool copy_name)
       : name_(copy_name ? reinterpret_cast<const char *>(malloc(length + 1)) : name),
-        length_(length), in_ignore_location_(false), in_read_only_location_(false) {
+        length_(length) {
     if (copy_name) {
       memcpy(const_cast<char*>(name_), name, length);
       const_cast<char*>(name_)[length] = '\0';
@@ -126,8 +126,8 @@ class FileName {
 
   const char * const name_;
   const uint32_t length_;
-  const bool in_ignore_location_;
-  const bool in_read_only_location_;
+  const bool in_ignore_location_ = false;
+  const bool in_read_only_location_ = false;
   static std::unordered_set<FileName, FileNameHasher>* db_;
   static tsl::hopscotch_map<const FileName*, XXH128_hash_t>* hash_db_;
   /** Number of FileOFDs open for writing referencing this file. */

--- a/src/firebuild/linear_buffer.h
+++ b/src/firebuild/linear_buffer.h
@@ -37,8 +37,7 @@ namespace firebuild {
 class LinearBuffer {
  public:
   LinearBuffer()
-      : size_(8 * 1024), buffer_(reinterpret_cast<char *>(malloc(size_))), data_start_offset_(0),
-        length_(0) {}
+      : buffer_(reinterpret_cast<char *>(malloc(size_))) {}
   ~LinearBuffer() {free(buffer_);}
   const char * data() const {
     return &buffer_[data_start_offset_];
@@ -120,10 +119,10 @@ class LinearBuffer {
   }
 
  private:
-  size_t size_;
+  size_t size_ = 8 * 1024;
   char * buffer_;
-  size_t data_start_offset_;
-  size_t length_;
+  size_t data_start_offset_ = 0;
+  size_t length_ = 0;
   void ensure_space(ssize_t howmuch) {
     TRACK(FB_DEBUG_COMM, "howmuch=%" PRIssize, howmuch);
 

--- a/src/firebuild/pipe.cc
+++ b/src/firebuild/pipe.cc
@@ -98,10 +98,9 @@ void Pipe::fd1_timeout_cb(void *arg) {
 
 Pipe::Pipe(int fd0_conn, Process* creator)
     : fd0_conn(fd0_conn),
-      conn2fd1_ends(), ffd2fd1_ends(), proc2recorders(), id_(id_counter_++), send_only_mode_(false),
-      fd0_shared_ptr_generated_(false), fd1_shared_ptr_generated_(false),
-      fd1_timeout_round_(0), buf_(), fd0_ptrs_held_self_ptr_(nullptr),
-      fd1_ptrs_held_self_ptr_(nullptr), shared_self_ptr_(this), creator_(creator) {
+      conn2fd1_ends(), ffd2fd1_ends(), proc2recorders(), id_(id_counter_++), buf_(),
+      fd0_ptrs_held_self_ptr_(nullptr), fd1_ptrs_held_self_ptr_(nullptr), shared_self_ptr_(this),
+      creator_(creator) {
   TRACKX(FB_DEBUG_PIPE, 0, 1, Pipe, this, "fd0_conn=%s, creator=%s", D_FD(fd0_conn), D(creator));
 }
 

--- a/src/firebuild/pipe.h
+++ b/src/firebuild/pipe.h
@@ -254,11 +254,11 @@ class Pipe {
   /* Unique Pipe ID, for debugging */
   int id_;
   /** Switch send only mode */
-  bool send_only_mode_:1;
-  bool fd0_shared_ptr_generated_:1;
-  bool fd1_shared_ptr_generated_:1;
+  bool send_only_mode_:1 = false;
+  bool fd0_shared_ptr_generated_:1 = false;
+  bool fd1_shared_ptr_generated_:1 = false;
   /** Number of times the fd1 timeout callback visited the pipe. */
-  unsigned int fd1_timeout_round_:3;
+  unsigned int fd1_timeout_round_:3 = 0;
   LinearBuffer buf_;
   int fd1_timeout_id_ = -1;
   /**

--- a/src/firebuild/process.cc
+++ b/src/firebuild/process.cc
@@ -58,10 +58,10 @@ static int fb_pid_counter;
 Process::Process(const int pid, const int ppid, const int exec_count, const FileName *wd,
                  const mode_t umask, Process * parent, std::vector<std::shared_ptr<FileFD>>* fds,
                  const bool debug_suppressed)
-    : parent_(parent), state_(FB_PROC_RUNNING),
+    : parent_(parent),
       fb_pid_(fb_pid_counter++), pid_(pid), ppid_(ppid), exec_count_(exec_count), wd_(wd),
       umask_(umask), fds_(fds), fork_children_(), expected_child_(),
-      debug_suppressed_(debug_suppressed), exec_child_(NULL) {
+      debug_suppressed_(debug_suppressed) {
   TRACKX(FB_DEBUG_PROC, 0, 1, Process, this, "pid=%d, ppid=%d, parent=%s", pid, ppid, D(parent));
 }
 

--- a/src/firebuild/process.h
+++ b/src/firebuild/process.h
@@ -624,7 +624,7 @@ class Process {
 
  private:
   Process *parent_;
-  process_state state_ :2;
+  process_state state_ :2 = FB_PROC_RUNNING;
   int fb_pid_;       ///< internal Firebuild id for the process
   int pid_;          ///< UNIX pid
   int ppid_;         ///< UNIX ppid
@@ -657,7 +657,7 @@ class Process {
   bool posix_spawn_pending_ {false};
   /** Debugging is suppressed for this process. */
   bool debug_suppressed_;
-  ExecedProcess * exec_child_;
+  ExecedProcess * exec_child_ = nullptr;
   const FileName* get_fd_filename(int fd) const;
   bool any_child_not_finalized();
   DISALLOW_COPY_AND_ASSIGN(Process);


### PR DESCRIPTION
Fixes #116.