### PR TITLE
Handle posix_spawn() with POSIX_SPAWN_SETEXEC attribute on macOS

### DIFF
--- a/src/common/fbbcomm.def
+++ b/src/common/fbbcomm.def
@@ -759,6 +759,10 @@
       (ARRAY, FBB, "file_actions"),
       # spawn or spawnp
       (REQUIRED, "bool", "is_spawnp"),
+      # user CPU time in microseconds since last exec() if POSIX_SPAWN_SETEXEC is set
+      (OPTIONAL, "int64_t", "utime_u"),
+      # system CPU time in microseconds since laste exec() if POSIX_SPAWN_SETEXEC is set
+      (OPTIONAL, "int64_t", "stime_u"),
     ]),
 
     ("posix_spawn_parent", [

--- a/src/interceptor/intercept.c
+++ b/src/interceptor/intercept.c
@@ -54,6 +54,7 @@ static void fb_ic_cleanup() __attribute__((destructor));
 
 fd_state ic_fd_states[IC_FD_STATES_SIZE];
 
+/** Resource usage at the process' last exec() */
 struct rusage initial_rusage;
 
 pthread_mutex_t ic_system_popen_lock = PTHREAD_MUTEX_INITIALIZER;
@@ -442,6 +443,12 @@ void pre_clone_disable_interception(const int flags, bool *i_locked) {
     release_global_lock();
     *i_locked = false;
   }
+}
+
+void rusage_since_exec(struct rusage *ru) {
+  get_ic_orig_getrusage()(RUSAGE_SELF, ru);
+  timersub(&ru->ru_stime, &initial_rusage.ru_stime, &ru->ru_stime);
+  timersub(&ru->ru_utime, &initial_rusage.ru_utime, &ru->ru_utime);
 }
 
 int clone_trampoline(void *arg) {

--- a/src/interceptor/intercept.h
+++ b/src/interceptor/intercept.h
@@ -65,6 +65,7 @@ extern psfa *psfas;
 extern int psfas_num;
 extern int psfas_alloc;
 
+struct rusage;
 /** This tells whether the supervisor needs to be notified on a read or write
  *  event. The supervisor needs to be notified only on the first of each kind,
  *  and only for file descriptors that were inherited by the process.
@@ -108,9 +109,6 @@ extern fd_state ic_fd_states[];
 /** Called unknown syscalls */
 #define IC_CALLED_SYSCALL_SIZE 1024
 extern bool ic_called_syscall[];
-
-/** Resource usage at the process' last exec() */
-extern struct rusage initial_rusage;
 
 /** Global lock for preventing parallel system and popen calls */
 extern pthread_mutex_t ic_system_popen_lock;
@@ -161,6 +159,9 @@ void pre_clone_disable_interception(const int flags, bool *i_locked);
 /** Function to call by the intercepted clone(), registering into the supervisor then
  calling the original clone() fn param. */
 int clone_trampoline(void *arg);
+
+/** Get CPU time used up since the previous exec() */
+void rusage_since_exec(struct rusage *ru);
 
 /** Connection string to supervisor */
 extern char fb_conn_string[FB_PATH_BUFSIZE];

--- a/src/interceptor/tpl_exec.c
+++ b/src/interceptor/tpl_exec.c
@@ -109,9 +109,7 @@
 
     /* Get CPU time used up to this exec() */
     struct rusage ru;
-    get_ic_orig_getrusage()(RUSAGE_SELF, &ru);
-    timersub(&ru.ru_stime, &initial_rusage.ru_stime, &ru.ru_stime);
-    timersub(&ru.ru_utime, &initial_rusage.ru_utime, &ru.ru_utime);
+    rusage_since_exec(&ru);
     fbbcomm_builder_exec_set_utime_u(&ic_msg,
         (int64_t)ru.ru_utime.tv_sec * 1000000 + (int64_t)ru.ru_utime.tv_usec);
     fbbcomm_builder_exec_set_stime_u(&ic_msg,


### PR DESCRIPTION
This fixes `g-ir-scanner` crash when compiling `librsvg`.