### PR TITLE
Ignore connecting to "/var/run/syslog" UNIX socket on macOS.

### DIFF
--- a/etc/firebuild.conf
+++ b/etc/firebuild.conf
@@ -157,8 +157,6 @@ quirks = [
   // This quirk allows shortcutting make and touch when it is run by lto-wrapper.
   // Since the internal make is started in /tmp the ignore-tmp-listing quirk needs to
   // be enabled as well to shortcut lto-wrapper.
-  // This quirk also allows shortcutting xcodebuild when it is invoked in the linking phase when
-  // LTO is enabled.
   "lto-wrapper",
   // dot (via libfontconfig) and other commands call (f)stafs() which don't impact the output.
   // Ignore those calls to allow shortcutting such processes.

--- a/src/common/fbbcomm.def
+++ b/src/common/fbbcomm.def
@@ -951,6 +951,7 @@
 
     ("connect", [
       (REQUIRED, "int", "sockfd"),
+      (OPTIONAL, STRING, "addr"),
       (OPTIONAL, "int", "error_no"),
     ]),
 

--- a/src/firebuild/process.h
+++ b/src/firebuild/process.h
@@ -493,7 +493,7 @@ class Process {
   /**
    * Handle connect() in the monitored process
    */
-  void handle_connect(const int sockfd, const int error);
+  void handle_connect(const int sockfd, const char * const address, const int error);
 
   /**
    * Handle dup(), dup2() or dup3() in the monitored process

--- a/src/firebuild/process_fbb_adaptor.h
+++ b/src/firebuild/process_fbb_adaptor.h
@@ -297,7 +297,9 @@ class ProcessFBBAdaptor {
   }
 
   static int handle(Process *proc, const FBBCOMM_Serialized_connect *msg) {
-    proc->handle_connect(msg->get_sockfd(), msg->get_error_no_with_fallback(0));
+    proc->handle_connect(msg->get_sockfd(),
+                         msg->get_addr(),
+                         msg->get_error_no_with_fallback(0));
     return 0;
   }
 

--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -2400,7 +2400,12 @@ generate("int", ["socket", "SYS_socket"]+ (["__socket"] if target == "linux" els
          after_lines=["if (i_am_intercepting && success) clear_notify_on_read_write_state(ret);"],
          send_ret_on_success=True)
 generate("int", ["connect", "SYS_connect", "__connect"], "int sockfd, const struct sockaddr *addr, socklen_t addrlen",
-         msg_skip_fields=["addr", "addrlen"])
+         msg_skip_fields=["addr", "addrlen"],
+         msg_add_fields=["if (((struct sockaddr*)addr)->sa_family == AF_UNIX) {",
+                         "  const char * const sun_path = ((struct sockaddr_un*)addr)->sun_path;",
+                         "  fbbcomm_builder_connect_set_addr_with_length(&ic_msg, sun_path, strnlen(sun_path, sizeof(((struct sockaddr_un*)addr)->sun_path)));",
+                         "}"],
+         )
 generate("int", ["bind", "SYS_bind"] + (["__bind"] if target == "darwin" else []), "int sockfd, const struct sockaddr *addr, socklen_t addrlen",
          tpl="once")
 generate("int", ["listen", "SYS_listen"] + (["__listen"] if target == "darwin" else []), "int sockfd, int backlog",

--- a/src/interceptor/interceptors.h
+++ b/src/interceptor/interceptors.h
@@ -54,6 +54,7 @@
 #endif
 #include <sys/resource.h>
 #include <sys/socket.h>
+#include <sys/un.h>
 #ifdef __APPLE__
 #include <sys/shm.h>
 #endif


### PR DESCRIPTION
This allows shortcutting programs such as xcodebuild that logs to syslog. The log messages are not replayed while shortcutting, though.