### PR TITLE
supervisor: Ignore connect()-ing to the sockets listed in ignore_locations

### DIFF
--- a/etc/firebuild.conf
+++ b/etc/firebuild.conf
@@ -123,7 +123,10 @@ ignore_locations = [
   "/proc/self",
   "/proc/stat",
   "/sys/devices",
-  "/sys/fs/cgroup"
+  "/sys/fs/cgroup",
+  // sockets connected to on macOS
+  "/var/run/syslog",
+  "/var/run/usbmuxd"
 ];
 
 // These files, directores, or any location under these directories assumed to be

--- a/src/firebuild/process.h
+++ b/src/firebuild/process.h
@@ -493,7 +493,8 @@ class Process {
   /**
    * Handle connect() in the monitored process
    */
-  void handle_connect(const int sockfd, const char * const address, const int error);
+  void handle_connect(const int sockfd, const char * const address, const size_t address_len,
+                      const int error);
 
   /**
    * Handle dup(), dup2() or dup3() in the monitored process

--- a/src/firebuild/process_fbb_adaptor.h
+++ b/src/firebuild/process_fbb_adaptor.h
@@ -299,6 +299,7 @@ class ProcessFBBAdaptor {
   static int handle(Process *proc, const FBBCOMM_Serialized_connect *msg) {
     proc->handle_connect(msg->get_sockfd(),
                          msg->get_addr(),
+                         msg->get_addr_len(),
                          msg->get_error_no_with_fallback(0));
     return 0;
   }


### PR DESCRIPTION
Expand ignoring such connect()-s on Linux, too, not just on macOS.

Add /var/run/syslog and /var/run/usbmuxd to ignore_locations.