### PR TITLE
interceptor: Reset rusage timers when reporting rusage to the supervisor

### DIFF
--- a/src/interceptor/intercept.c
+++ b/src/interceptor/intercept.c
@@ -451,6 +451,11 @@ void rusage_since_exec(struct rusage *ru) {
   timersub(&ru->ru_utime, &initial_rusage.ru_utime, &ru->ru_utime);
 }
 
+void reset_rusage() {
+  timerclear(&initial_rusage.ru_stime);
+  timerclear(&initial_rusage.ru_utime);
+}
+
 int clone_trampoline(void *arg) {
   clone_trampoline_arg *trampoline_arg = (clone_trampoline_arg *)arg;
   thread_signal_danger_zone_leave();
@@ -751,8 +756,7 @@ void atfork_child_handler(void) {
   /* ic_pid still have parent process' pid */
   pid_t ppid = ic_pid;
   /* Reset, getrusage will report the correct self resource usage. */
-  timerclear(&initial_rusage.ru_stime);
-  timerclear(&initial_rusage.ru_utime);
+  reset_rusage();
   /* Reinitialize the lock, see #207.
    *
    * We don't know if the lock was previously held, we'd need to check

--- a/src/interceptor/intercept.h
+++ b/src/interceptor/intercept.h
@@ -163,6 +163,9 @@ int clone_trampoline(void *arg);
 /** Get CPU time used up since the previous exec() */
 void rusage_since_exec(struct rusage *ru);
 
+/** Reset rusage timers used for reporting rusage to the supervisor. */
+void reset_rusage();
+
 /** Connection string to supervisor */
 extern char fb_conn_string[FB_PATH_BUFSIZE];
 

--- a/src/interceptor/tpl_exec.c
+++ b/src/interceptor/tpl_exec.c
@@ -110,6 +110,7 @@
     /* Get CPU time used up to this exec() */
     struct rusage ru;
     rusage_since_exec(&ru);
+    reset_rusage();
     fbbcomm_builder_exec_set_utime_u(&ic_msg,
         (int64_t)ru.ru_utime.tv_sec * 1000000 + (int64_t)ru.ru_utime.tv_usec);
     fbbcomm_builder_exec_set_stime_u(&ic_msg,

--- a/src/interceptor/tpl_posix_spawn.c
+++ b/src/interceptor/tpl_posix_spawn.c
@@ -60,6 +60,7 @@
         if (attr_flags & POSIX_SPAWN_SETEXEC) {
           struct rusage ru;
           rusage_since_exec(&ru);
+          reset_rusage();
           fbbcomm_builder_posix_spawn_set_utime_u(
               &ic_msg, (int64_t)ru.ru_utime.tv_sec * 1000000 + (int64_t)ru.ru_utime.tv_usec);
           fbbcomm_builder_posix_spawn_set_stime_u(


### PR DESCRIPTION
This prevents adding the same resource usage multiple times when exec() or friends fail.