### PR TITLE
interceptor: Identify posix_spawn_file_actions_t handles by their full content

### DIFF
--- a/src/interceptor/intercept.h
+++ b/src/interceptor/intercept.h
@@ -48,23 +48,6 @@
 #include "common/firebuild_common.h"
 #include "./fbbcomm.h"
 
-/** A poor man's (plain C) implementation of a hashmap:
- *  posix_spawn_file_actions_t -> char**
- *  implemented as a dense array with linear lookup.
- *
- *  Each file action is encoded as a simple string, e.g.
- *  - open:  "o 10 0 0 /etc/hosts"
- *  - close: "c 11"
- *  - dup2:  "d 3 5"
- */
-typedef struct {
-  const posix_spawn_file_actions_t *p;
-  voidp_array actions;
-} psfa;
-extern psfa *psfas;
-extern int psfas_num;
-extern int psfas_alloc;
-
 struct rusage;
 /** This tells whether the supervisor needs to be notified on a read or write
  *  event. The supervisor needs to be notified only on the first of each kind,
@@ -196,6 +179,12 @@ extern void psfa_init(const posix_spawn_file_actions_t *p);
  * Do not shrink psfas.
  */
 extern void psfa_destroy(const posix_spawn_file_actions_t *p);
+/**
+ * Update our pool's entry if the pointer in posix_spawn_file_actions_t we use for identifying
+ * entries internally changed.
+ */
+void psfa_update_actions(const posix_spawn_file_actions_t* old_actions,
+                         const posix_spawn_file_actions_t* new_actions);
 /**
  * Additional bookkeeping to do after a successful posix_spawn_file_actions_addopen():
  * Append a corresponding FBBCOMM_Builder_posix_spawn_file_action_open builder to our structures.

--- a/src/interceptor/tpl_posix_spawn_file_actions.c
+++ b/src/interceptor/tpl_posix_spawn_file_actions.c
@@ -20,6 +20,7 @@
 {# ------------------------------------------------------------------ #}
 ### extends "tpl.c"
 
+### set init_or_destroy = func in ["posix_spawn_file_actions_init", "posix_spawn_file_actions_destroy"]
 ### block guard_connection_fd
 {# Override the main template's corresponding block so that the       #}
 {# connection fd is _not_ guarded here. This is because matching the  #}
@@ -30,8 +31,17 @@
 {# preceding posix_spawn_file_action. See #875 for further details.   #}
 ### endblock
 
+### block before
+###   if not init_or_destroy
+    const posix_spawn_file_actions_t file_actions_orig = *file_actions;
+###   endif
+### endblock before
+
 ### block after
   if (success) {
+###   if not init_or_destroy
+    psfa_update_actions(&file_actions_orig, file_actions);
+###   endif
     {{ func | replace("posix_spawn_file_actions_", "psfa_") }} ({{ names_str }});
   }
 ### endblock after


### PR DESCRIPTION
This helps in not losing track of the objects when they are copied inside the intercepted processses.