### PR TITLE
build: Configure include and library paths in CMake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -334,7 +334,7 @@ jobs:
       run: |
         export PATH=/usr/local/opt/ccache/libexec:$PATH
         export PYTHONPATH=$(ls -d /usr/local/lib/python*/site-packages | tail -n1)
-        cmake -DCMAKE_CXX_FLAGS="-I/usr/local/include" -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/lib" -DCMAKE_BUILD_TYPE=Debug .
+        cmake -DCMAKE_BUILD_TYPE=Debug .
         make -j2
     - name: test
       run: |

--- a/README.md
+++ b/README.md
@@ -126,8 +126,7 @@ Install the build dependencies:
 Build:
 
     export XML_CATALOG_FILES=/usr/local/etc/xml/catalog
-    export PATH=$(ls -d /opt/homebrew/Cellar/jinja2-cli/*/libexec/bin):$PATH
-    cmake -DCMAKE_CXX_FLAGS="-I/opt/homebrew/include -I/usr/local/include" -DCMAKE_EXE_LINKER_FLAGS="-L/opt/homebrew/lib" .
+    cmake .
     make check
 
 Install:

--- a/src/firebuild/CMakeLists.txt
+++ b/src/firebuild/CMakeLists.txt
@@ -31,6 +31,9 @@ if (SANITIZE)
   endif()
 endif()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${tsl-hopscotch-map_INCLUDE_DIRS}")
+set_source_files_properties(config.cc PROPERTIES INCLUDE_DIRECTORIES "${LIBCONFIGPP_INCLUDE_DIR}")
+
 add_custom_command(
   OUTPUT fbbfp.cc fbbfp.h fbbfp_decode.c
   DEPENDS fbbfp.def
@@ -89,7 +92,7 @@ add_executable(firebuild-bin
   fbbstore.cc
   $<TARGET_OBJECTS:common_objs>
   $<TARGET_OBJECTS:fbbcomm_cc>)
-target_link_libraries(firebuild-bin ${LIBCONFIGPP_LIBRARY} ${JEMALLOC_LIBRARIES} ${XXHASH_LIBRARIES} ${PLIST_LINK_LIBRARIES} ${IOKit} ${CoreFoundation})
+target_link_libraries(firebuild-bin ${LIBCONFIGPP_LIBRARY} ${JEMALLOC_LDFLAGS} ${XXHASH_LDFLAGS} ${PLIST_LINK_LIBRARIES} ${IOKit} ${CoreFoundation})
 target_link_options(firebuild-bin PUBLIC -Wno-array-bounds -Wno-strict-overflow ${SANITIZE_SUPERVISOR_LINK_OPTIONS})
 set_target_properties(firebuild-bin PROPERTIES OUTPUT_NAME firebuild)
 # GCC 9's LTO implementation seem to have a bug we hit, but did not fully triage yet


### PR DESCRIPTION
This allows simpler build commands when some of the dependencies are found in non-standard locations.