### PR TITLE
supervisor: Don't reopen inherited closed pipe

### DIFF
--- a/src/firebuild/message_processor.cc
+++ b/src/firebuild/message_processor.cc
@@ -171,6 +171,11 @@ void MessageProcessor::accept_exec_child(ExecedProcess* proc, int fd_conn,
           auto file_fd_old = proc->get_shared_fd(inherited_file.fds[0]);
           auto pipe = file_fd_old->pipe();
           assert(pipe);
+          if (pipe->finished()) {
+            /* Pipe may have been closed (or broken) before the supervisor started accepting
+             * the new child*/
+            continue;
+          }
 
           /* As per #689, reopening the pipes causes different behavior than without firebuild. With
            * firebuild, across an exec they no longer share the same "open file description" and thus


### PR DESCRIPTION
This fixes firebuild crashing while intercepting apparmor's build on Ubuntu 23.10 when the build experiences a broken pipe:

...
make[2]: Entering directory '/home/ubuntu/perftest-build/apparmor/apparmor-4.0.0~alpha2/parser' ESC[01mESC[K<stdin>:3:ESC[mESC[K ESC[01;31mESC[Kfatal error: ESC[mESC[Kwhen writing output to : Invalid argument compilation terminated.
ESC[01mESC[K<stdin>:2:ESC[mESC[K ESC[01;31mESC[Kfatal error: ESC[mESC[Kwhen writing output to : Broken pipe compilation terminated.
../common/list_af_names.sh > generated_af_names.h
...

The build itself continues fine despite this printout.