### PR TITLE
debian: Switch order of autopkgtest tests

### DIFF
--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,7 +1,7 @@
-Tests: recompile-bash
-Depends: bash, bc, debconf, time
-Restrictions: needs-root, allow-stderr
-
 Tests: build-time-tests-with-installed-firebuild
 Depends: @builddeps@
+Restrictions: needs-root, allow-stder
+
+Tests: recompile-bash
+Depends: bash, bc, debconf, time
 Restrictions: needs-root, allow-stderr


### PR DESCRIPTION
This moves the bash rebuild acceleration performance to the end of the test logs.