### PR TITLE
supervisor: Fix unhandled case in ENOTDIR handling

### DIFF
--- a/src/firebuild/file_usage_update.cc
+++ b/src/firebuild/file_usage_update.cc
@@ -129,7 +129,7 @@ bool FileUsageUpdate::get_initial_hash(Hash *hash_ptr) const {
   }
 }
 
-void FileUsageUpdate::update_from_enotdir(const FileName * const filename) {
+FileUsageUpdate* FileUsageUpdate::update_from_enotdir(const FileName * const filename) {
   bool is_dir;
 
   if (hash_cache->get_statinfo(filename, &is_dir, nullptr)) {
@@ -141,6 +141,7 @@ void FileUsageUpdate::update_from_enotdir(const FileName * const filename) {
       set_initial_type(ISREG);
     }
     parent_type_ = ISDIR;
+    return this;
   } else {
     /* filename is not a regular file or a directory, but open returned ENOTDIR.
      * Let's take a look at the parent. */
@@ -157,6 +158,13 @@ void FileUsageUpdate::update_from_enotdir(const FileName * const filename) {
         /* Set not existing filename's type to DONTKNOW to omit it from the process inputs. */
         set_initial_type(DONTKNOW);
       }
+      return this;
+    } else {
+      /* We could not stat parent, let's just register an error. */
+      // TODO(rbalint) maybe stat() parent directly
+      parent_type_ = DONTKNOW;
+      unknown_err_ = ENOTDIR;
+      return this;
     }
   }
 }

--- a/src/firebuild/file_usage_update.h
+++ b/src/firebuild/file_usage_update.h
@@ -111,7 +111,7 @@ class FileUsageUpdate {
    * O_DIRECTORY flag set.
    * Update the FileUsageUpdate according to the case.
    */
-  void update_from_enotdir(const FileName * const filename);
+  FileUsageUpdate* update_from_enotdir(const FileName * const filename);
 
   /* The file's contents were altered by the process, e.g. written to, or modified in any other way,
    * including removal of the file, or another file getting renamed to this one. */


### PR DESCRIPTION
Also return value from update_from_enotdir() to notice possible unhandled branches.