### PR TITLE
interceptor: Intercept __send on arm64 Linux

### DIFF
--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -1163,7 +1163,7 @@ for v in ['', 'v']:
     skip(c1 + v + "asprintf" + c2)
 
 for func_guard in [(["send", "SYS_send"], None),
-                   ("__send", "#if !defined __aarch64__")]:
+                   ("__send", "#if !defined(__aarch64__) || !defined(__APPLE__)")]:
   (func, ifdef_guard) = func_guard
   generate("ssize_t", func, "int fd, const void *buf, size_t len, int flags",
            platforms=(["linux"] if func == "__send" else ["darwin", "linux"]),


### PR DESCRIPTION
This fixes the test failure due to the missing symbol on Ubuntu 20.04.