### PR TITLE
interceptor: Fix casting to the right passed size_t type in count_shared_libs_cb

### DIFF
--- a/src/interceptor/intercept.c
+++ b/src/interceptor/intercept.c
@@ -683,7 +683,7 @@ static bool skip_shared_lib(const char *name, const size_t len) {
 int count_shared_libs_cb(struct dl_phdr_info *info, const size_t size, void *data) {
   (void)info;  /* unused */
   (void)size;  /* unused */
-  int* count = (int*)data;
+  size_t* count = (size_t*)data;
   (*count)++;
   return 0;
 }


### PR DESCRIPTION
This wrong cast made the interceptor crash in s390x builds in intercepting dlopen().

Follow up for commit f57fa38979365c42265b6d68aa13a2165faf8346.