### PR TITLE
supervisor: Don't override SIGSEGV handler when dumping core is allowed

### DIFF
--- a/src/firebuild/firebuild.cc
+++ b/src/firebuild/firebuild.cc
@@ -242,8 +242,12 @@ int main(const int argc, char *argv[]) {
   sa.sa_flags = 0;
   sigaction(SIGINT, &sa, NULL);
   sigaction(SIGQUIT, &sa, NULL);
-  sigaction(SIGSEGV, &sa, NULL);
   sigaction(SIGTERM, &sa, NULL);
+  /* Don't override SIGSEGV handler when dumping core is enabled. */
+  struct rlimit rlim;
+  if ((getrlimit(RLIMIT_CORE, &rlim) == 0) && (rlim.rlim_cur == 0)) {
+    sigaction(SIGSEGV, &sa, NULL);
+  }
 
   /* Configure epoll */
   firebuild::epoll = new firebuild::Epoll();


### PR DESCRIPTION
This may leave the cache in an inconsistent state, but lets the coredump be useful for debugging.

Follow up for commit f074f86b2ed06d36807ac004e56965b938ebfde5.