### PR TITLE
interceptor: Don't intercept __send on arm64 Linux starting with glibc 2.34

### DIFF
--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -1238,7 +1238,7 @@ for v in ['', 'v']:
     skip(c1 + v + "asprintf" + c2)
 
 for func_guard in [(["send", "SYS_send"], None),
-                   ("__send", "#if !defined(__aarch64__) || !defined(__APPLE__)")]:
+                   ("__send", "#if !defined(__aarch64__) || (defined(__linux__) && !__GLIBC_PREREQ(2, 34))")]:
   (func, ifdef_guard) = func_guard
   generate("ssize_t", func, "int fd, const void *buf, size_t len, int flags",
            platforms=(["linux"] if func == "__send" else ["darwin", "linux"]),


### PR DESCRIPTION
Glibc stopped exporting the symbol in 2.34.