### PR TITLE
supervisor: Don't intercept sandbox-exec

### DIFF
--- a/etc/firebuild.conf
+++ b/etc/firebuild.conf
@@ -66,7 +66,9 @@ processes = {
     // hangs, also has its own caching framework
     "gradle",
     // Go has its own caching framework
-    "go"
+    "go",
+    // sandbox-exec prevents the interception of the sandboxed process
+    "sandbox-exec"
   ];
 
   // Processes that we could cache and shortcut, but prefer not to (for example


### PR DESCRIPTION
It is used on MacOS and the sandboxed app crashes otherwise, because the interceptor can't connect to the supervisor.