### PR TITLE
interceptor: Sort environment variables if they were fixed up by the interceptor

### DIFF
--- a/src/common/firebuild_common.c
+++ b/src/common/firebuild_common.c
@@ -161,6 +161,14 @@ void voidp_set_erase(voidp_set *set, const void *p) {
   }
 }
 
+/** Compare pointers to char* like strcmp() for char* */
+int cmpstringpp(const void *p1, const void *p2) {
+  /* The actual arguments to this function are "pointers to
+     pointers to char", but strcmp(3) arguments are "pointers
+     to char", hence the following cast plus dereference */
+  return strcmp(* (char * const *) p1, * (char * const *) p2);
+}
+
 /**
  * Checks if a path semantically begins with one of the given sorted subpaths.
  *

--- a/src/common/firebuild_common.h
+++ b/src/common/firebuild_common.h
@@ -97,6 +97,9 @@ bool voidp_set_contains(const voidp_set *set, const void *p);
 void voidp_set_insert(voidp_set *set, const void *p);
 void voidp_set_erase(voidp_set *set, const void *p);
 
+/** Compare pointers to char* like strcmp() for char* */
+int cmpstringpp(const void *p1, const void *p2);
+
 bool is_path_at_locations(const char *path, const ssize_t len,
                           const cstring_view_array *prefix_array);
 

--- a/src/interceptor/env.c
+++ b/src/interceptor/env.c
@@ -277,6 +277,7 @@ void env_fixup(char **env, void *buf) {
     *buf1++ = env[i];
   }
 
+  qsort(buf, buf1 - (char**)buf, sizeof(char**), cmpstringpp);
   *buf1 = NULL;
 }
 

--- a/src/interceptor/intercept.c
+++ b/src/interceptor/intercept.c
@@ -595,14 +595,6 @@ int main() {
 
 #endif  /* unittests for canonicalize_path() */
 
-/** Compare pointers to char* like strcmp() for char* */
-static int cmpstringpp(const void *p1, const void *p2) {
-  /* The actual arguments to this function are "pointers to
-     pointers to char", but strcmp(3) arguments are "pointers
-     to char", hence the following cast plus dereference */
-  return strcmp(* (char * const *) p1, * (char * const *) p2);
-}
-
 /** Store from entries from environment variable. */
 static void store_entries(const char* env_var, cstring_view_array *entries,
                           char * entries_env_buf, size_t buffer_size) {


### PR DESCRIPTION
This speeds up sorting them in the transitive children, when sending the environment
variables to the supervisor in libfirebuild's init.