### PR TITLE
Bitrise: Save built firebuild as a build artifact

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -30,6 +30,7 @@ workflows:
             make -C build-make -j$NPROC
             make -C build-make -j$NPROC check
             sudo make -C build-make install
+            tar --zstd -cf ${BITRISE_DEPLOY_DIR}/firebuild-$(git log -1 --format=%cd-%h --date=format:%Y-%m-%d).tar.zst /usr/local/bin/firebuild /usr/local/lib/libfirebuild.* /usr/local/etc/firebuild.conf /usr/local/share/firebuild
             # build self with Xcode
             for i in 1 2; do
               rm -rf build-xcode

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -47,7 +47,7 @@ workflows:
 meta:
   bitrise.io:
     stack: osx-xcode-edge
-    machine_type_id: g2-m1.4core
+    machine_type_id: g2.mac.medium
 trigger_map:
 - push_branch: master
   workflow: primary


### PR DESCRIPTION
Also change configuration to list the runner which is going to run the build due to Bitrise mapping M1 workers to M2 ones automatically.