### PR TITLE
ci: Stop testing on macos-12 runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,7 +311,7 @@ jobs:
         HOMEBREW_NO_AUTO_UPDATE: 1
     strategy:
       matrix:
-        os: [macos-12, macos-14]
+        os: [macos-14]
     needs: style-checks
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30


### PR DESCRIPTION
Brew bundle takes really long time and times out after 29 minutes. Also macOS 12 is quite old, probably no one is really interested in running Firebuild on it.