### PR TITLE
ci: Close fds up to 200 in close_fds_exec

### DIFF
--- a/test/close_fds_exec.c
+++ b/test/close_fds_exec.c
@@ -22,7 +22,7 @@ int main(int argc, char* argv[]) {
   (void) argc;  /* unused */
 
   int i;
-  for (i = 3; i < 120; i++) {
+  for (i = 3; i < 200; i++) {
     close(i);
   }
   execvp(argv[1], &argv[1]);


### PR DESCRIPTION
Apparently commands inherit fd 155 and 158 in GitHub Actions, that breaks test with Valgrind.

https://github.com/actions/runner-images/issues/3729