### PR TITLE
ci: Don't test on Ubuntu 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,7 +275,7 @@ jobs:
   build-deb:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
     needs: style-checks
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
@@ -294,7 +294,6 @@ jobs:
         key: build-deb-${{ matrix.os }}
     - name: install-deps
       run: |
-        ! [ ${{ matrix.os }} == "ubuntu-20.04" ] || sudo add-apt-repository -y -n ppa:firebuild/build-deps
         sudo apt update
         sudo apt-get build-dep .
     - name: deb


### PR DESCRIPTION
GitHub stops supporting the 20.04 runners on 2025-04-01 and the end of the 5 year standard support period is close for 20.04 anyway.