### PR TITLE
macos: Pass -DCMAKE_OSX_SYSROOT=macosx to cmake on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -342,7 +342,7 @@ jobs:
         export XML_CATALOG_FILES=${HOMEBREW_PREFIX}/etc/xml/catalog
         export PATH=${HOMEBREW_PREFIX}/opt/ccache/libexec:$PATH
         export PYTHONPATH=$(ls -d ${HOMEBREW_PREFIX}/Cellar/jinja2-cli/*/libexec/lib/*/site-packages | tail -n1)
-        cmake -DCMAKE_BUILD_TYPE=Debug -B build-make
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_SYSROOT=macosx -B build-make
         make -C build-make -j$(getconf _NPROCESSORS_ONLN)
     - name: test
       run: |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Install the build dependencies:
 
 Build:
 
-    cmake .
+    cmake -DCMAKE_OSX_SYSROOT=macosx .
     HOMEBREW_PREFIX=$(ls -d /opt/homebrew /usr/local 2> /dev/null| head -n1)
     export XML_CATALOG_FILES=${HOMEBREW_PREFIX}/etc/xml/catalog
     export PYTHONPATH=$(ls -d ${HOMEBREW_PREFIX}/Cellar/jinja2-cli/*/libexec/lib/*/site-packages | tail -n1)

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -26,7 +26,7 @@ workflows:
             NPROC="$(getconf _NPROCESSORS_ONLN)"
             export PYTHONPATH=$(ls -d /opt/homebrew/Cellar/jinja2-cli/*/libexec/lib/*/site-packages | tail -n1)
             sudo defaults write /Library/Preferences/com.apple.security.libraryvalidation.plist DisableLibraryValidation -bool true
-            cmake -DCMAKE_BUILD_TYPE=Release -B build-make
+            cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_SYSROOT=macosx -B build-make
             make -C build-make -j$NPROC
             make -C build-make -j$NPROC check
             sudo make -C build-make install


### PR DESCRIPTION
Otherwise CMake 4.0.0 and later sets CMAKE_OSX_SYSROOT to empty by default.

See: https://gitlab.kitware.com/cmake/cmake/-/commit/7b195312919cbf69497af2514b91b55bd9a6da71