### PR TITLE
bitrise: Drop cache restoring and saving steps

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -9,7 +9,6 @@ workflows:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@8:
         is_always_run: true
-    - cache-pull@2: {}
     - brew-install@1:
         inputs:
         - cache_enabled: 'yes'
@@ -39,7 +38,6 @@ workflows:
                time firebuild -o env_vars.pass_through+=\"PYTHONPATH\" -o env_vars.pass_through+=\"XML_CATALOG_FILES\" xcodebuild)
             done
     - deploy-to-bitrise-io@2: {}
-    - cache-push@2: {}
     envs:
     - opts:
         is_expand: false


### PR DESCRIPTION
Bitrise deprecated branch-based caching and only brew-install used it until it dropped support for it, too.