### PR TITLE
macos: Stop intercepting deprecated posix_spawn_file_actions_add(f)chdir_np

### DIFF
--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -2120,11 +2120,13 @@ generate("int", "posix_spawn_file_actions_adddup2", "posix_spawn_file_actions_t 
          tpl="posix_spawn_file_actions",
          success="ret == 0")
 generate("int", "posix_spawn_file_actions_addchdir_np", "posix_spawn_file_actions_t *file_actions, const char *pathname",
-         ifdef_guard=glibc_ge(2, 29) + " || defined(__APPLE__)",
+         platforms=['linux'],
+         ifdef_guard=glibc_ge(2, 29),
          tpl="posix_spawn_file_actions",
          success="ret == 0")
 generate("int", "posix_spawn_file_actions_addfchdir_np", "posix_spawn_file_actions_t *file_actions, int fd",
-         ifdef_guard=glibc_ge(2, 29) + " || defined(__APPLE__)",
+         platforms=['linux'],
+         ifdef_guard=glibc_ge(2, 29),
          tpl="posix_spawn_file_actions",
          success="ret == 0")
 generate("int", "posix_spawn_file_actions_addinherit_np", "posix_spawn_file_actions_t *file_actions, int filedes",

--- a/test/test_cmd_posix_spawn.c
+++ b/test/test_cmd_posix_spawn.c
@@ -58,9 +58,8 @@ int main(int argc, char *argv[]) {
   posix_spawn_file_actions_adddup2(&file_actions, 97, 98);
   posix_spawn_file_actions_adddup2(&file_actions, 1, 1);
   posix_spawn_file_actions_addclose(&file_actions, 97);
-#if __GLIBC_PREREQ(2, 29) || defined(__APPLE__)
+#if __GLIBC_PREREQ(2, 29)
   posix_spawn_file_actions_addchdir_np(&file_actions, ".");
-  /* This call fails on macOS when using an fd opened by the posix spawn file actions. */
   posix_spawn_file_actions_addfchdir_np(&file_actions,
 #ifdef __APPLE__
                                         open(".", O_RDONLY, 0));


### PR DESCRIPTION
This fixes the build on macOS CI.