### PR TITLE
Intercept getrlimit(), setrlimit() and prlimit() calls

### DIFF
--- a/src/common/debug_sysflags.c
+++ b/src/common/debug_sysflags.c
@@ -23,6 +23,7 @@
 #include <sched.h>
 #include <spawn.h>
 #include <stdio.h>
+#include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -817,6 +818,43 @@ void debug_clone_flags(FILE *f, int flags) {
   DEBUG_BITMAP_END_HEX(f, flags & ~0xff);
   fprintf(f, "|");
   debug_signum(f, flags & 0xff);
+}
+
+void debug_rlimit_resource(FILE *f, int resource) {
+  DEBUG_VALUE_START(f, resource);
+#ifndef __APPLE__
+  DEBUG_VALUE_VALUE(f, resource, RLIMIT_AS);
+#endif
+  DEBUG_VALUE_VALUE(f, resource, RLIMIT_CORE);
+  DEBUG_VALUE_VALUE(f, resource, RLIMIT_CPU);
+  DEBUG_VALUE_VALUE(f, resource, RLIMIT_DATA);
+  DEBUG_VALUE_VALUE(f, resource, RLIMIT_FSIZE);
+#ifdef RLIMIT_LOCKS
+  DEBUG_VALUE_VALUE(f, resource, RLIMIT_LOCKS);
+#endif
+#ifdef RLIMIT_MEMLOCK
+  DEBUG_VALUE_VALUE(f, resource, RLIMIT_MEMLOCK);
+#endif
+#ifdef RLIMIT_MSGQUEUE
+  DEBUG_VALUE_VALUE(f, resource, RLIMIT_MSGQUEUE);
+#endif
+#ifdef RLIMIT_NICE
+  DEBUG_VALUE_VALUE(f, resource, RLIMIT_NICE);
+#endif
+  DEBUG_VALUE_VALUE(f, resource, RLIMIT_NOFILE);
+  DEBUG_VALUE_VALUE(f, resource, RLIMIT_NPROC);
+  DEBUG_VALUE_VALUE(f, resource, RLIMIT_RSS);
+#ifdef RLIMIT_RTPRIO
+  DEBUG_VALUE_VALUE(f, resource, RLIMIT_RTPRIO);
+#endif
+#ifdef RLIMIT_RTTIME
+  DEBUG_VALUE_VALUE(f, resource, RLIMIT_RTTIME);
+#endif
+#ifdef RLIMIT_SIGPENDING
+  DEBUG_VALUE_VALUE(f, resource, RLIMIT_SIGPENDING);
+#endif
+  DEBUG_VALUE_VALUE(f, resource, RLIMIT_STACK);
+  DEBUG_VALUE_END_DEC(f, resource);
 }
 
 #ifdef __cplusplus

--- a/src/common/debug_sysflags.h
+++ b/src/common/debug_sysflags.h
@@ -42,6 +42,7 @@ void debug_signum(FILE *f, int signum);
 void debug_mode_t(FILE *f, mode_t mode);
 void debug_wstatus(FILE *f, int wstatus);
 void debug_clone_flags(FILE *f, int flags);
+void debug_rlimit_resource(FILE *f, int resource);
 
 #ifdef __cplusplus
 }  /* extern "C" */

--- a/src/common/fbbcomm.def
+++ b/src/common/fbbcomm.def
@@ -111,6 +111,14 @@
       fprintf(f, "\\"");
     }
 
+    /* Debugger method for int fields that represent RLIMIT_* values */
+    static void fbbcomm_debug_rlimit_resource(FILE *f, int resource, bool is_serialized, const void *fbb) {
+      (void)is_serialized;  /* unused */
+      (void)fbb;  /* unused */
+      fprintf(f, "\\"");
+      debug_rlimit_resource(f, resource);
+      fprintf(f, "\\"");
+    }
   """,
 
   "extra_h": """
@@ -983,5 +991,16 @@
       # error no., when ret = -1
       (OPTIONAL, "int", "error_no"),
     ]),
+
+    # Message for getrlimit(), setrlimit() and prlimit().
+    # prlimit() can get and set limits at the same time.
+    ("rlimit", [
+      (REQUIRED, "int", "resource", "fbbcomm_debug_rlimit_resource"),
+      (REQUIRED, "bool", "get"),
+      (REQUIRED, "bool", "set"),
+      # error no., when ret = -1
+      (OPTIONAL, "int", "error_no"),
+      (OPTIONAL, "int", "pid"),
+    ])
   ]
 }

--- a/src/firebuild/message_processor.cc
+++ b/src/firebuild/message_processor.cc
@@ -1359,6 +1359,16 @@ static void proc_ic_msg(const FBBCOMM_Serialized *fbbcomm_buf, uint16_t ack_num,
       /* Ignore __mac_syscall(). Having the tag defined allows easier debugging with -d comm. */
       // TODO(rbalint) check if any __mac_syscall() invocation could impact builds
       break;
+    case FBBCOMM_TAG_rlimit: {
+      auto msg = reinterpret_cast<const FBBCOMM_Serialized_rlimit *>(fbbcomm_buf);
+      if (msg->has_error_no()) {
+        proc->exec_point()->disable_shortcutting_bubble_up(
+            "Changing resource limits failed");
+      } else {
+        /* Ignore success */
+      }
+      break;
+    }
     case FBBCOMM_TAG_fb_debug:
     case FBBCOMM_TAG_fb_error:
     case FBBCOMM_TAG_fchownat:

--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -2457,7 +2457,22 @@ generate("int", "SYS_seccomp", "unsigned int operation, unsigned int flags, void
                           "}",
                           ])
 
-# FIXME {get,set,p}rlimit
+generate("int", ["getrlimit", "__getrlimit", "getrlimit64", "SYS_getrlimit"], "int resource, struct rlimit *rlim",
+         msg="rlimit",
+         msg_skip_fields=["rlim"],
+         msg_add_fields=["fbbcomm_builder_rlimit_set_get(&ic_msg, true);",
+                          "fbbcomm_builder_rlimit_set_set(&ic_msg, false);"])
+generate("int", ["setrlimit", "setrlimit64", "SYS_setrlimit"] + ["__setrlimit"] if target == "darwin" else [], "int resource, const struct rlimit *rlim",
+         msg="rlimit",
+         msg_skip_fields=["rlim"],
+         msg_add_fields=["fbbcomm_builder_rlimit_set_get(&ic_msg, false);",
+                          "fbbcomm_builder_rlimit_set_set(&ic_msg, true);"])
+generate("int", ["prlimit", "prlimit64", "SYS_prlimit64"], "pid_t pid, int resource, const struct rlimit64 *new_limit, struct rlimit64 *old_limit",
+         platforms=['linux'],
+         msg="rlimit",
+         msg_skip_fields=["new_limit", "old_limit"],
+         msg_add_fields=["fbbcomm_builder_rlimit_set_get(&ic_msg, old_limit != NULL);",
+                          "fbbcomm_builder_rlimit_set_set(&ic_msg, new_limit != NULL);"])
 
 # User and group stuff
 # FIXME shall we notify the supervisor?


### PR DESCRIPTION
Disable shortcutting when the call fail.