### PR TITLE
interceptor: Mark utimensat() and futimens() as safe to intercept remapped

### DIFF
--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -146,6 +146,7 @@ safe_remapped_functions = set({
   "freopen",
   "fstatfs",
   "fstatvfs",
+  "futimens",
   "gettimeofday",
   "ioctl",
   "mkostemp",
@@ -170,6 +171,7 @@ safe_remapped_functions = set({
   "time",
   "tmpfile",
   "utime",
+  "utimensat",
   "utimes",
   "wait3",
   "wait4"


### PR DESCRIPTION
This fixes armhf builds where the 64 bit variant should be in use.