### PR TITLE
interceptor: Allow intercepting close() when already intercepting fclose()

### DIFF
--- a/src/interceptor/generate_interceptors
+++ b/src/interceptor/generate_interceptors
@@ -648,8 +648,11 @@ generate("int", ["close", "SYS_close", "__close_nocancel"] + (["close$NOCANCEL"]
 generate("int", "fclose", "FILE *stream",
          before_lines=["int fd = safe_fileno(stream); /* save it here, we can't do fileno() after the fclose() */",
                        "if (i_am_intercepting) set_notify_on_read_write_state(fd);",
+                       "/* close() may be intercepted inside fclose() */",
+                       "FB_THREAD_LOCAL(interception_recursion_depth)++;",
                        "voidp_set_erase(&popened_streams, stream);"],
-         send_msg_condition="fd != -1",
+         after_lines=["FB_THREAD_LOCAL(interception_recursion_depth)--;"],
+         send_msg_condition="fd != -1 && strcmp(FB_THREAD_LOCAL(intercept_on), \"fclose\") == 0",
          msg="close",
          msg_skip_fields=["stream"],
          msg_add_fields=["fbbcomm_builder_close_set_fd(&ic_msg, fd);"])

--- a/test/test_file_ops.c
+++ b/test/test_file_ops.c
@@ -142,6 +142,19 @@ int main() {
   }
   close(fd);
 
+  FILE *f;
+  f = fopen("test_nonempty_2.txt", "w");
+  if (f == NULL) {
+    perror("fopen" LOC);
+    exit(1);
+  }
+  i = fwrite(msg, 1, strlen(msg), f);
+  if (i != (int) strlen(msg)) {
+    perror("fwrite" LOC);
+    exit(1);
+  }
+  fclose(f);
+
   /* Only create _1, and not _2. */
   fd = creat("test_maybe_exists_1.txt", 0600);
   if (fd == -1) {


### PR DESCRIPTION
The close message will be sent only once to the supervisor.

Fixes intercepting "grub-mknetdir --help".