### PR TITLE
supervisor: Pass static binaries to qemu with full path as argument

### DIFF
--- a/src/firebuild/command_rewriter.cc
+++ b/src/firebuild/command_rewriter.cc
@@ -115,6 +115,10 @@ void CommandRewriter::maybe_rewrite(
 #ifndef __APPLE__
   bool is_static = false;
   if (qemu_user && hash_cache && hash_cache->get_is_static(*executable, &is_static) && is_static) {
+    if (args->size() > 0 && !strchr((*args)[0].c_str(), '/')) {
+      /* Replace the first argument with the original static executable's path. */
+      (*args)[0] = (*executable)->to_string();
+    }
     *executable = qemu_user;
     *rewritten_executable = true;
     args->insert(args->begin(), {(*executable)->to_string(), QEMU_LIBC_SYSCALLS_OPTION});


### PR DESCRIPTION
when the static binary would be resolved on the path.

Qemu does not resolve binaries to run on the path, thus just passing
 qemu-user-interposable -libc-syscalls static-sh
would fail.